### PR TITLE
support for non-std::string keys

### DIFF
--- a/include/boost/property_tree/detail/json_parser_read.hpp
+++ b/include/boost/property_tree/detail/json_parser_read.hpp
@@ -32,9 +32,8 @@ namespace boost { namespace property_tree { namespace json_parser
     template<class Ptree>
     struct context
     {
-
-        typedef typename Ptree::key_type::value_type Ch;
-        typedef std::basic_string<Ch> Str;
+	typedef typename Ptree::key_type Str;
+        typedef typename Str::value_type Ch;
         typedef typename std::vector<Ch>::iterator It;
 
         Str string;
@@ -162,7 +161,8 @@ namespace boost { namespace property_tree { namespace json_parser
     {
 
         typedef context<Ptree> Context;
-        typedef typename Ptree::key_type::value_type Ch;
+        typedef typename Ptree::key_type Str;
+        typedef typename Str::value_type Ch;
 
         mutable Context c;
 
@@ -239,8 +239,8 @@ namespace boost { namespace property_tree { namespace json_parser
                     =   !ch_p("-") >>
                         (ch_p("0") | (range_p(Ch('1'), Ch('9')) >> *digit_p)) >>
                         !(ch_p(".") >> +digit_p) >>
-                        !(chset_p(detail::widen<Ch>("eE").c_str()) >>
-                          !chset_p(detail::widen<Ch>("-+").c_str()) >>
+                        !(chset_p(detail::widen<Str>("eE").c_str()) >>
+                          !chset_p(detail::widen<Str>("-+").c_str()) >>
                           +digit_p)
                         ;
 
@@ -255,7 +255,7 @@ namespace boost { namespace property_tree { namespace json_parser
                     ;
 
                 escape
-                    =   chset_p(detail::widen<Ch>("\"\\/bfnrt").c_str())
+                    =   chset_p(detail::widen<Str>("\"\\/bfnrt").c_str())
                             [typename Context::a_escape(self.c)]
                     |   'u' >> uint_parser<unsigned long, 16, 4, 4>()
                             [typename Context::a_unicode(self.c)]

--- a/include/boost/property_tree/detail/ptree_utils.hpp
+++ b/include/boost/property_tree/detail/ptree_utils.hpp
@@ -54,49 +54,48 @@ namespace boost { namespace property_tree { namespace detail
 
 
     // Naively convert narrow string to another character type
-    template<class Ch>
-    std::basic_string<Ch> widen(const char *text)
+    template<typename Str>
+    Str widen(const char *text)
     {
-        std::basic_string<Ch> result;
+	Str result;
         while (*text)
         {
-            result += Ch(*text);
+            result += typename Str::value_type(*text);
             ++text;
         }
         return result;
     }
 
     // Naively convert string to narrow character type
-    template<class Ch>
-    std::string narrow(const Ch *text)
+    template<typename Str, typename char_type>
+    Str narrow(const char_type *text)
     {
-        std::string result;
+	Str result;
         while (*text)
         {
             if (*text < 0 || *text > (std::numeric_limits<char>::max)())
                 result += '*';
             else
-                result += char(*text);
+                result += typename Str::value_type(*text);
             ++text;
         }
         return result;
     }
 
     // Remove trailing and leading spaces
-    template<class Ch>
-    std::basic_string<Ch> trim(const std::basic_string<Ch> &s,
-                               const std::locale &loc = std::locale())
+    template<class Str>
+    Str trim(const Str &s, const std::locale &loc = std::locale())
     {
-        typename std::basic_string<Ch>::const_iterator first = s.begin();
-        typename std::basic_string<Ch>::const_iterator end = s.end();
+        typename Str::const_iterator first = s.begin();
+        typename Str::const_iterator end = s.end();
         while (first != end && std::isspace(*first, loc))
             ++first;
         if (first == end)
-            return std::basic_string<Ch>();
-        typename std::basic_string<Ch>::const_iterator last = end;
+            return Str();
+        typename Str::const_iterator last = end;
         do --last; while (std::isspace(*last, loc));
         if (first != s.begin() || last + 1 != end)
-            return std::basic_string<Ch>(first, last + 1);
+            return Str(first, last + 1);
         else
             return s;
     }

--- a/include/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
+++ b/include/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
@@ -38,14 +38,13 @@ namespace boost { namespace property_tree { namespace xml_parser
                 if (node->first_attribute())
                 {
                     Ptree &pt_attr_root = pt_node.push_back(
-                        std::make_pair(xmlattr<Ch>(), Ptree()))->second;
+                        std::make_pair(xmlattr<typename Ptree::key_type>(), Ptree()))->second;
                     for (xml_attribute<Ch> *attr = node->first_attribute();
                          attr; attr = attr->next_attribute())
                     {
                         Ptree &pt_attr = pt_attr_root.push_back(
                             std::make_pair(attr->name(), Ptree()))->second;
-                        pt_attr.data() = std::basic_string<Ch>(attr->value(),
-                                                            attr->value_size());
+                        pt_attr.data() = typename Ptree::key_type(attr->value(), attr->value_size());
                     }
                 }
 
@@ -61,11 +60,10 @@ namespace boost { namespace property_tree { namespace xml_parser
             case node_cdata:
             {
                 if (flags & no_concat_text)
-                    pt.push_back(std::make_pair(xmltext<Ch>(),
+                    pt.push_back(std::make_pair(xmltext<typename Ptree::key_type>(),
                                                 Ptree(node->value())));
                 else
-                    pt.data() += std::basic_string<Ch>(node->value(),
-                                                       node->value_size());
+                    pt.data() += typename Ptree::key_type(node->value(), node->value_size());
             }
             break;
 
@@ -73,9 +71,8 @@ namespace boost { namespace property_tree { namespace xml_parser
             case node_comment:
             {
                 if (!(flags & no_comments))
-                    pt.push_back(std::make_pair(xmlcomment<Ch>(),
-                                    Ptree(std::basic_string<Ch>(node->value(),
-                                                         node->value_size()))));
+                    pt.push_back(std::make_pair(xmlcomment<typename Ptree::key_type>(),
+                                    Ptree(typename Ptree::key_type(node->value(), node->value_size()))));
             }
             break;
 

--- a/include/boost/property_tree/detail/xml_parser_utils.hpp
+++ b/include/boost/property_tree/detail/xml_parser_utils.hpp
@@ -20,14 +20,15 @@
 namespace boost { namespace property_tree { namespace xml_parser
 {
 
-    template<class Ch>
-    std::basic_string<Ch> condense(const std::basic_string<Ch> &s)
+    template<class Str>
+    Str condense(const Str &s)
     {
-        std::basic_string<Ch> r;
+	typedef typename Str::value_type Ch;
+	Str r;
         std::locale loc;
         bool space = false;
-        typename std::basic_string<Ch>::const_iterator end = s.end();
-        for (typename std::basic_string<Ch>::const_iterator it = s.begin();
+        typename Str::const_iterator end = s.end();
+        for (typename Str::const_iterator it = s.begin();
              it != end; ++it)
         {
             if (isspace(*it, loc) || *it == Ch('\n'))
@@ -41,20 +42,22 @@ namespace boost { namespace property_tree { namespace xml_parser
         return r;
     }
 
-    template<class Ch>
-    std::basic_string<Ch> encode_char_entities(const std::basic_string<Ch> &s)
+
+    template<class Str>
+    Str encode_char_entities(const Str &s)
     {
         // Don't do anything for empty strings.
         if(s.empty()) return s;
 
-        typedef typename std::basic_string<Ch> Str;
+        typedef typename Str::value_type Ch;
+
         Str r;
         // To properly round-trip spaces and not uglify the XML beyond
         // recognition, we have to encode them IF the text contains only spaces.
         Str sp(1, Ch(' '));
         if(s.find_first_not_of(sp) == Str::npos) {
             // The first will suffice.
-            r = detail::widen<Ch>("&#32;");
+            r = detail::widen<Str>("&#32;");
             r += Str(s.size() - 1, Ch(' '));
         } else {
             typename Str::const_iterator end = s.end();
@@ -62,13 +65,13 @@ namespace boost { namespace property_tree { namespace xml_parser
             {
                 switch (*it)
                 {
-                    case Ch('<'): r += detail::widen<Ch>("&lt;"); break;
-                    case Ch('>'): r += detail::widen<Ch>("&gt;"); break;
-                    case Ch('&'): r += detail::widen<Ch>("&amp;"); break;
-                    case Ch('"'): r += detail::widen<Ch>("&quot;"); break;
-                    case Ch('\''): r += detail::widen<Ch>("&apos;"); break;
-                    case Ch('\t'): r += detail::widen<Ch>("&#9;"); break;
-                    case Ch('\n'): r += detail::widen<Ch>("&#10;"); break;
+                    case Ch('<'): r += detail::widen<Str>("&lt;"); break;
+                    case Ch('>'): r += detail::widen<Str>("&gt;"); break;
+                    case Ch('&'): r += detail::widen<Str>("&amp;"); break;
+                    case Ch('"'): r += detail::widen<Str>("&quot;"); break;
+                    case Ch('\''): r += detail::widen<Str>("&apos;"); break;
+                    case Ch('\t'): r += detail::widen<Str>("&#9;"); break;
+                    case Ch('\n'): r += detail::widen<Str>("&#10;"); break;
                     default: r += *it; break;
                 }
             }
@@ -76,10 +79,10 @@ namespace boost { namespace property_tree { namespace xml_parser
         return r;
     }
     
-    template<class Ch>
-    std::basic_string<Ch> decode_char_entities(const std::basic_string<Ch> &s)
+    template<class Str>
+    Str decode_char_entities(const Str &s)
     {
-        typedef typename std::basic_string<Ch> Str;
+	typedef typename Str::value_type Ch;
         Str r;
         typename Str::const_iterator end = s.end();
         for (typename Str::const_iterator it = s.begin(); it != end; ++it)
@@ -90,11 +93,11 @@ namespace boost { namespace property_tree { namespace xml_parser
                 if (semicolon == end)
                     BOOST_PROPERTY_TREE_THROW(xml_parser_error("invalid character entity", "", 0));
                 Str ent(it + 1, semicolon);
-                if (ent == detail::widen<Ch>("lt")) r += Ch('<');
-                else if (ent == detail::widen<Ch>("gt")) r += Ch('>');
-                else if (ent == detail::widen<Ch>("amp")) r += Ch('&');
-                else if (ent == detail::widen<Ch>("quot")) r += Ch('"');
-                else if (ent == detail::widen<Ch>("apos")) r += Ch('\'');
+                if (ent == detail::widen<Str>("lt")) r += Ch('<');
+                else if (ent == detail::widen<Str>("gt")) r += Ch('>');
+                else if (ent == detail::widen<Str>("amp")) r += Ch('&');
+                else if (ent == detail::widen<Str>("quot")) r += Ch('"');
+                else if (ent == detail::widen<Str>("apos")) r += Ch('\'');
                 else
                     BOOST_PROPERTY_TREE_THROW(xml_parser_error("invalid character entity", "", 0));
                 it = semicolon;
@@ -105,31 +108,31 @@ namespace boost { namespace property_tree { namespace xml_parser
         return r;
     }
     
-    template<class Ch>
-    const std::basic_string<Ch> &xmldecl()
+    template<class Str>
+    const Str &xmldecl()
     {
-        static std::basic_string<Ch> s = detail::widen<Ch>("<?xml>");
+        static Str s = detail::widen<Str>("<?xml>");
         return s;
     }
 
-    template<class Ch>
-    const std::basic_string<Ch> &xmlattr()
+    template<class Str>
+    const Str &xmlattr()
     {
-        static std::basic_string<Ch> s = detail::widen<Ch>("<xmlattr>");
+        static Str s = detail::widen<Str>("<xmlattr>");
         return s;
     }
 
-    template<class Ch>
-    const std::basic_string<Ch> &xmlcomment()
+    template<class Str>
+    const Str &xmlcomment()
     {
-        static std::basic_string<Ch> s = detail::widen<Ch>("<xmlcomment>");
+        static Str s = detail::widen<Str>("<xmlcomment>");
         return s;
     }
 
-    template<class Ch>
-    const std::basic_string<Ch> &xmltext()
+    template<class Str>
+    const Str &xmltext()
     {
-        static std::basic_string<Ch> s = detail::widen<Ch>("<xmltext>");
+        static Str s = detail::widen<Str>("<xmltext>");
         return s;
     }
 

--- a/include/boost/property_tree/detail/xml_parser_write.hpp
+++ b/include/boost/property_tree/detail/xml_parser_write.hpp
@@ -19,23 +19,24 @@
 
 namespace boost { namespace property_tree { namespace xml_parser
 {
-    template<class Ch>
-    void write_xml_indent(std::basic_ostream<Ch> &stream,
+    template<class Str>
+    void write_xml_indent(std::basic_ostream<typename Str::value_type> &stream,
           int indent,
-          const xml_writer_settings<Ch> & settings
+          const xml_writer_settings<Str> & settings
           )
     {
-        stream << std::basic_string<Ch>(indent * settings.indent_count, settings.indent_char);
+        stream << std::basic_string<typename Str::value_type>(indent * settings.indent_count, settings.indent_char);
     }
 
-    template<class Ch>
-    void write_xml_comment(std::basic_ostream<Ch> &stream,
-                           const std::basic_string<Ch> &s, 
+    template<class Str>
+    void write_xml_comment(std::basic_ostream<typename Str::value_type> &stream,
+                           const Str &s,
                            int indent,
                            bool separate_line,
-                           const xml_writer_settings<Ch> & settings
+                           const xml_writer_settings<Str> & settings
                            )
     {
+	typedef typename Str::value_type Ch;
         if (separate_line)
             write_xml_indent(stream,indent,settings);
         stream << Ch('<') << Ch('!') << Ch('-') << Ch('-');
@@ -45,14 +46,15 @@ namespace boost { namespace property_tree { namespace xml_parser
             stream << Ch('\n');
     }
     
-    template<class Ch>
-    void write_xml_text(std::basic_ostream<Ch> &stream,
-                        const std::basic_string<Ch> &s, 
+    template<class Str>
+    void write_xml_text(std::basic_ostream<typename Str::value_type> &stream,
+                        const Str &s,
                         int indent, 
                         bool separate_line,
-                        const xml_writer_settings<Ch> & settings
+                        const xml_writer_settings<Str> & settings
                         )
     {
+	typedef typename Str::value_type Ch;
         if (separate_line)    
             write_xml_indent(stream,indent,settings);
         stream << encode_char_entities(s);
@@ -62,13 +64,13 @@ namespace boost { namespace property_tree { namespace xml_parser
 
     template<class Ptree>
     void write_xml_element(std::basic_ostream<typename Ptree::key_type::value_type> &stream, 
-                           const std::basic_string<typename Ptree::key_type::value_type> &key,
+                           const typename Ptree::key_type &key,
                            const Ptree &pt, 
                            int indent,
-                           const xml_writer_settings<typename Ptree::key_type::value_type> & settings)
+                           const xml_writer_settings<typename Ptree::key_type> & settings)
     {
-
         typedef typename Ptree::key_type::value_type Ch;
+        typedef typename Ptree::key_type Str;
         typedef typename Ptree::const_iterator It;
 
         bool want_pretty = settings.indent_count > 0;
@@ -77,10 +79,10 @@ namespace boost { namespace property_tree { namespace xml_parser
         bool has_attrs_only = pt.data().empty();
         for (It it = pt.begin(), end = pt.end(); it != end; ++it)
         {
-            if (it->first != xmlattr<Ch>() )
+            if (it->first != xmlattr<Str>() )
             {
                 has_attrs_only = false;
-                if (it->first != xmltext<Ch>())
+                if (it->first != xmltext<Str>())
                 {
                     has_elements = true;
                     break;
@@ -112,12 +114,12 @@ namespace boost { namespace property_tree { namespace xml_parser
                 stream << Ch('<') << key;
 
                 // Write attributes
-                if (optional<const Ptree &> attribs = pt.get_child_optional(xmlattr<Ch>()))
+                if (optional<const Ptree &> attribs = pt.get_child_optional(xmlattr<Str>()))
                     for (It it = attribs.get().begin(); it != attribs.get().end(); ++it)
                         stream << Ch(' ') << it->first << Ch('=')
                                << Ch('"')
                                << encode_char_entities(
-                                    it->second.template get_value<std::basic_string<Ch> >())
+                                    it->second.template get_value<Str>())
                                << Ch('"');
 
                 if ( has_attrs_only )
@@ -141,21 +143,21 @@ namespace boost { namespace property_tree { namespace xml_parser
             // Write data text, if present
             if (!pt.data().empty())
                 write_xml_text(stream,
-                    pt.template get_value<std::basic_string<Ch> >(),
+                    pt.template get_value<Str>(),
                     indent + 1, has_elements && want_pretty, settings);
 
             // Write elements, comments and texts
             for (It it = pt.begin(); it != pt.end(); ++it)
             {
-                if (it->first == xmlattr<Ch>())
+                if (it->first == xmlattr<Str>())
                     continue;
-                else if (it->first == xmlcomment<Ch>())
+                else if (it->first == xmlcomment<Str>())
                     write_xml_comment(stream,
-                        it->second.template get_value<std::basic_string<Ch> >(),
+                        it->second.template get_value<Str>(),
                         indent + 1, want_pretty, settings);
-                else if (it->first == xmltext<Ch>())
+                else if (it->first == xmltext<Str>())
                     write_xml_text(stream,
-                        it->second.template get_value<std::basic_string<Ch> >(),
+                        it->second.template get_value<Str>(),
                         indent + 1, has_elements && want_pretty, settings);
                 else
                     write_xml_element(stream, it->first, it->second,
@@ -179,13 +181,12 @@ namespace boost { namespace property_tree { namespace xml_parser
     void write_xml_internal(std::basic_ostream<typename Ptree::key_type::value_type> &stream, 
                             const Ptree &pt,
                             const std::string &filename,
-                            const xml_writer_settings<typename Ptree::key_type::value_type> & settings)
+                            const xml_writer_settings<typename Ptree::key_type> & settings)
     {
-        typedef typename Ptree::key_type::value_type Ch;
-        typedef typename std::basic_string<Ch> Str;
-        stream  << detail::widen<Ch>("<?xml version=\"1.0\" encoding=\"")
+        typedef typename Ptree::key_type Str;
+        stream  << detail::widen<Str>("<?xml version=\"1.0\" encoding=\"")
                 << settings.encoding
-                << detail::widen<Ch>("\"?>\n");
+                << detail::widen<Str>("\"?>\n");
         write_xml_element(stream, Str(), pt, -1, settings);
         if (!stream)
             BOOST_PROPERTY_TREE_THROW(xml_parser_error("write error", filename, 0));

--- a/include/boost/property_tree/detail/xml_parser_writer_settings.hpp
+++ b/include/boost/property_tree/detail/xml_parser_writer_settings.hpp
@@ -18,10 +18,11 @@ namespace boost { namespace property_tree { namespace xml_parser
 {
     
     // Naively convert narrow string to another character type
-    template<class Ch>
-    std::basic_string<Ch> widen(const char *text)
+    template<class Str>
+    Str widen(const char *text)
     {
-        std::basic_string<Ch> result;
+	typedef typename Str::value_type Ch;
+        Str result;
         while (*text)
         {
             result += Ch(*text);
@@ -31,13 +32,14 @@ namespace boost { namespace property_tree { namespace xml_parser
     }
 
     //! Xml writer settings. The default settings lead to no pretty printing.
-    template<class Ch>
+    template<class Str>
     class xml_writer_settings
     {
+	typedef typename Str::value_type Ch;
     public:
         xml_writer_settings(Ch inchar = Ch(' '),
-                typename std::basic_string<Ch>::size_type incount = 0,
-                const std::basic_string<Ch> &enc = widen<Ch>("utf-8"))
+                typename Str::size_type incount = 0,
+                const Str &enc = widen<Str>("utf-8"))
             : indent_char(inchar)
             , indent_count(incount)
             , encoding(enc)
@@ -45,16 +47,16 @@ namespace boost { namespace property_tree { namespace xml_parser
         }
 
         Ch indent_char;
-        typename std::basic_string<Ch>::size_type indent_count;
-        std::basic_string<Ch> encoding;
+        typename Str::size_type indent_count;
+        Str encoding;
     };
 
-    template <class Ch>
-    xml_writer_settings<Ch> xml_writer_make_settings(Ch indent_char = Ch(' '),
-        typename std::basic_string<Ch>::size_type indent_count = 0,
-        const std::basic_string<Ch> &encoding = widen<Ch>("utf-8"))
+    template <class Str>
+    xml_writer_settings<Str> xml_writer_make_settings(typename Str::value_type indent_char = (typename Str::value_type)(' '),
+        typename Str::size_type indent_count = 0,
+        const Str &encoding = widen<Str>("utf-8"))
     {
-        return xml_writer_settings<Ch>(indent_char, indent_count, encoding);
+        return xml_writer_settings<Str>(indent_char, indent_count, encoding);
     }
 
 } } }

--- a/include/boost/property_tree/string_path.hpp
+++ b/include/boost/property_tree/string_path.hpp
@@ -61,7 +61,7 @@ namespace boost { namespace property_tree
 #ifndef BOOST_NO_STD_WSTRING
         inline std::string dump_sequence(const std::wstring &s)
         {
-            return narrow(s.c_str());
+            return narrow<std::string>(s.c_str());
         }
 #endif
     }

--- a/include/boost/property_tree/xml_parser.hpp
+++ b/include/boost/property_tree/xml_parser.hpp
@@ -102,9 +102,9 @@ namespace boost { namespace property_tree { namespace xml_parser
                    > &stream,
                    const Ptree &pt,
                    const xml_writer_settings<
-                       typename Ptree::key_type::value_type
+                       typename Ptree::key_type
                    > & settings = xml_writer_settings<
-                                    typename Ptree::key_type::value_type>() )
+                                    typename Ptree::key_type>() )
     {
         write_xml_internal(stream, pt, std::string(), settings);
     }
@@ -125,9 +125,8 @@ namespace boost { namespace property_tree { namespace xml_parser
                    const Ptree &pt,
                    const std::locale &loc = std::locale(),
                    const xml_writer_settings<
-                       typename Ptree::key_type::value_type
-                   > & settings = xml_writer_settings<
-                                    typename Ptree::key_type::value_type>())
+                       typename Ptree::key_type
+                   > & settings = xml_writer_settings<typename Ptree::key_type>())
     {
         std::basic_ofstream<typename Ptree::key_type::value_type>
             stream(filename.c_str());

--- a/test/test_property_tree.hpp
+++ b/test/test_property_tree.hpp
@@ -797,9 +797,6 @@ void test_get_put(PTREE *)
                                     
 void test_get_child_put_child(PTREE *)
 {
-
-    typedef std::basic_string<CHTYPE> str_t;
-
     PTREE pt(T("ala ma kota"));
 
     // Do insertions via put_child
@@ -1076,7 +1073,6 @@ void test_custom_data_type(PTREE *)
 
     typedef std::basic_string<CHTYPE> Str;
     typedef PTREE::key_compare Comp;
-    typedef PTREE::path_type Path;
 
     // Property_tree with boost::any as data type
     typedef boost::property_tree::basic_ptree<Str, boost::any, Comp> my_ptree;

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -81,13 +81,13 @@ template<class Ptree>
 Ptree get_test_ptree()
 {
     using namespace boost::property_tree;
-    typedef typename Ptree::key_type::value_type Ch;
+    typedef typename Ptree::key_type Str;
     Ptree pt;
-    pt.put_value(detail::widen<Ch>("data0"));
-    pt.put(detail::widen<Ch>("key1"), detail::widen<Ch>("data1"));
-    pt.put(detail::widen<Ch>("key1.key"), detail::widen<Ch>("data2"));
-    pt.put(detail::widen<Ch>("key2"), detail::widen<Ch>("data3"));
-    pt.put(detail::widen<Ch>("key2.key"), detail::widen<Ch>("data4"));
+    pt.put_value(detail::widen<Str>("data0"));
+    pt.put(detail::widen<Str>("key1"), detail::widen<Str>("data1"));
+    pt.put(detail::widen<Str>("key1.key"), detail::widen<Str>("data2"));
+    pt.put(detail::widen<Str>("key2"), detail::widen<Str>("data3"));
+    pt.put(detail::widen<Str>("key2.key"), detail::widen<Str>("data4"));
     return pt;
 }
 
@@ -104,7 +104,6 @@ void generic_parser_test(Ptree &pt,
 {
 
     using namespace boost::property_tree;
-    typedef typename Ptree::key_type::value_type Ch;
 
     // Create test files
     test_file file_1(test_data_1, filename_1);
@@ -236,7 +235,8 @@ void check_exact_roundtrip(ReadFunc rf, WriteFunc wf, const char *test_data) {
               << test_data << "\n-----\n";
     using namespace boost::property_tree;
     typedef typename Ptree::key_type::value_type Ch;
-    std::basic_string<Ch> native_test_data = detail::widen<Ch>(test_data);
+    typedef typename Ptree::key_type Str;
+    Str native_test_data = detail::widen<Str>(test_data);
 
     std::basic_istringstream<Ch> in_stream(native_test_data);
     std::basic_ostringstream<Ch> out_stream;

--- a/test/test_xml_parser_common.hpp
+++ b/test/test_xml_parser_common.hpp
@@ -49,8 +49,7 @@ struct WriteFuncNS
     void operator()(const std::string &filename, const Ptree &pt) const
     {
         boost::property_tree::write_xml(filename, pt, std::locale(),
-            boost::property_tree::xml_writer_make_settings(
-                typename Ptree::key_type::value_type(' '), 4));
+            boost::property_tree::xml_writer_make_settings<typename Ptree::key_type>(' ', 4));
     }
 };
 


### PR DESCRIPTION
This patch allowes to load/save xmls from ptrees with non-std::string keys 
