### PR TITLE
Fix MSVC warning

### DIFF
--- a/include/boost/property_tree/detail/info_parser_read.hpp
+++ b/include/boost/property_tree/detail/info_parser_read.hpp
@@ -69,7 +69,7 @@ namespace boost { namespace property_tree { namespace info_parser
         unsigned n = c;
         if (n > 127)
             return false;
-        return isspace(c);
+        return isspace(c) != 0;
     }
 
     // Advance pointer past whitespace


### PR DESCRIPTION
warning C4800: 'int' : forcing value to bool 'true' or 'false' (performance warning)
Fixed by explicitly comparing the return value of isspace to zero.
