### PR TITLE
Fix escape misbehavior on basic_string<char>.

### DIFF
--- a/include/boost/property_tree/detail/json_parser_write.hpp
+++ b/include/boost/property_tree/detail/json_parser_write.hpp
@@ -29,11 +29,13 @@ namespace boost { namespace property_tree { namespace json_parser
         typename std::basic_string<Ch>::const_iterator e = s.end();
         while (b != e)
         {
+            typedef typename make_unsigned<Ch>::type UCh;
+            UCh c(*b);
             // This assumes an ASCII superset. But so does everything in PTree.
             // We escape everything outside ASCII, because this code can't
             // handle high unicode characters.
-            if (*b == 0x20 || *b == 0x21 || (*b >= 0x23 && *b <= 0x2E) ||
-                (*b >= 0x30 && *b <= 0x5B) || (*b >= 0x5D && *b <= 0xFF))
+            if (c == 0x20 || c == 0x21 || (c >= 0x23 && c <= 0x2E) ||
+                (c >= 0x30 && c <= 0x5B) || (c >= 0x5D && c <= 0xFF))
                 result += *b;
             else if (*b == Ch('\b')) result += Ch('\\'), result += Ch('b');
             else if (*b == Ch('\f')) result += Ch('\\'), result += Ch('f');
@@ -46,7 +48,6 @@ namespace boost { namespace property_tree { namespace json_parser
             else
             {
                 const char *hexdigits = "0123456789ABCDEF";
-                typedef typename make_unsigned<Ch>::type UCh;
                 unsigned long u = (std::min)(static_cast<unsigned long>(
                                                  static_cast<UCh>(*b)),
                                              0xFFFFul);

--- a/test/test_json_parser.cpp
+++ b/test/test_json_parser.cpp
@@ -414,14 +414,38 @@ void test_json_parser()
 
 }
 
+template <typename T>
+void test_escaping();
+
+template <>
+void test_escaping<char>()
+{
+    std::string str = "Мама мыла раму";
+    // Should NOT escape UTF-8
+    BOOST_CHECK(boost::property_tree::json_parser::create_escapes(str) == str);
+}
+
+template <>
+void test_escaping<wchar_t>()
+{
+    // Should NOT escape characters within ASCII range.
+    std::wstring str1 = L"I am wstring with ASCII";
+    BOOST_CHECK(boost::property_tree::json_parser::create_escapes(str1) == str1);
+    // Should escape characters outside ASCII range - this is NOT utf-8
+    std::wstring str2 = L"Мама мыла раму";
+    BOOST_CHECK(boost::property_tree::json_parser::create_escapes(str2) == L"\\u041C\\u0430\\u043C\\u0430 \\u043C\\u044B\\u043B\\u0430 \\u0440\\u0430\\u043C\\u0443");
+}
+
 int test_main(int argc, char *argv[])
 {
     using namespace boost::property_tree;
     test_json_parser<ptree>();
     test_json_parser<iptree>();
+    test_escaping<char>();
 #ifndef BOOST_NO_CWCHAR
     test_json_parser<wptree>();
     test_json_parser<wiptree>();
+    test_escaping<wchar_t>();
 #endif
     return 0;
 }


### PR DESCRIPTION
Signed entity used for byte comparison, which fails for signed char.
Due to this JSON serialization spits \uXXXX monstrosity instead of
proper UTF-8.