### PR TITLE
fixed wrong filename in landing page example

### DIFF
--- a/examples/debug_settings.cpp
+++ b/examples/debug_settings.cpp
@@ -83,7 +83,7 @@ int main()
     try
     {
         debug_settings ds;
-        ds.load("debug_settings_xml");
+        ds.load("debug_settings.xml");
         ds.save("debug_settings_out.xml");
         std::cout << "Success\n";
     }


### PR DESCRIPTION
didn't want to file a bug report for such a small thing