### PR TITLE
[Trac #11502] Fix "always true comparison" warning in narrow_encoding.hpp

### DIFF
--- a/include/boost/property_tree/detail/json_parser/narrow_encoding.hpp
+++ b/include/boost/property_tree/detail/json_parser/narrow_encoding.hpp
@@ -68,7 +68,7 @@ namespace boost { namespace property_tree {
         }
 
         char to_internal_trivial(char c) const {
-            assert(c <= 0x7f);
+            assert(static_cast<unsigned char>(c) <= 0x7f);
             return c;
         }
 


### PR DESCRIPTION
Hi,

This is a small fix for Trac #11502 https://svn.boost.org/trac/boost/ticket/11502

gcc 4.9 reports us this warning:
error: comparison is always true due to limited range of data type [-Werror=type-limits] 

Cheers,
Romain