### PR TITLE
Fix warnings about a missing return. Port to BOOST_ASSERT.

### DIFF
--- a/include/boost/property_tree/detail/json_parser/narrow_encoding.hpp
+++ b/include/boost/property_tree/detail/json_parser/narrow_encoding.hpp
@@ -1,9 +1,9 @@
 #ifndef BOOST_PROPERTY_TREE_DETAIL_JSON_PARSER_NARROW_ENCODING_HPP
 #define BOOST_PROPERTY_TREE_DETAIL_JSON_PARSER_NARROW_ENCODING_HPP
 
+#include <boost/assert.hpp>
 #include <boost/range/iterator_range_core.hpp>
 
-#include <cassert>
 #include <utility>
 
 namespace boost { namespace property_tree {
@@ -68,7 +68,7 @@ namespace boost { namespace property_tree {
         }
 
         char to_internal_trivial(char c) const {
-            assert(c <= 0x7f);
+            BOOST_ASSERT(c <= 0x7f);
             return c;
         }
 

--- a/include/boost/property_tree/detail/json_parser/parser.hpp
+++ b/include/boost/property_tree/detail/json_parser/parser.hpp
@@ -225,304 +225,304 @@ namespace boost { namespace property_tree {
         Iterator& cur;
     };
 
-	template <typename Callbacks, typename Encoding, typename Iterator,
+    template <typename Callbacks, typename Encoding, typename Iterator,
               typename Sentinel>
-	class parser
-	{
-		typedef detail::number_callback_adapter<Callbacks, Encoding, Iterator>
+    class parser
+    {
+        typedef detail::number_callback_adapter<Callbacks, Encoding, Iterator>
             number_adapter;
-		typedef detail::string_callback_adapter<Callbacks, Encoding, Iterator>
+        typedef detail::string_callback_adapter<Callbacks, Encoding, Iterator>
             string_adapter;
-		typedef detail::source<Encoding, Iterator, Sentinel> source;
-		typedef typename source::code_unit code_unit;
+        typedef detail::source<Encoding, Iterator, Sentinel> source;
+        typedef typename source::code_unit code_unit;
 
-	public:
-		parser(Callbacks& callbacks, Encoding& encoding)
-			: callbacks(callbacks), encoding(encoding), src(encoding)
-		{}
+    public:
+        parser(Callbacks& callbacks, Encoding& encoding)
+            : callbacks(callbacks), encoding(encoding), src(encoding)
+        {}
 
-		template <typename Range>
-		void set_input(const std::string& filename, const Range& r) {
-			src.set_input(filename, r);
-		}
+        template <typename Range>
+        void set_input(const std::string& filename, const Range& r) {
+            src.set_input(filename, r);
+        }
 
-		void finish() {
-		    skip_ws();
-			if (!src.done()) {
-				parse_error("garbage after data");
-			}
-		}
+        void finish() {
+            skip_ws();
+            if (!src.done()) {
+                parse_error("garbage after data");
+            }
+        }
 
-		void parse_value() {
-			if (parse_object()) return;
-			if (parse_array()) return;
-			if (parse_string()) return;
-			if (parse_boolean()) return;
-			if (parse_null()) return;
-			if (parse_number()) return;
-			parse_error("expected value");
-		}
+        void parse_value() {
+            if (parse_object()) return;
+            if (parse_array()) return;
+            if (parse_string()) return;
+            if (parse_boolean()) return;
+            if (parse_null()) return;
+            if (parse_number()) return;
+            parse_error("expected value");
+        }
 
-		bool parse_null() {
-			skip_ws();
-			if (!have(&Encoding::is_n)) {
-				return false;
-			}
-			expect(&Encoding::is_u, "expected 'null'");
-			expect(&Encoding::is_l, "expected 'null'");
-			expect(&Encoding::is_l, "expected 'null'");
-			callbacks.on_null();
-			return true;
-		}
+        bool parse_null() {
+            skip_ws();
+            if (!have(&Encoding::is_n)) {
+                return false;
+            }
+            expect(&Encoding::is_u, "expected 'null'");
+            expect(&Encoding::is_l, "expected 'null'");
+            expect(&Encoding::is_l, "expected 'null'");
+            callbacks.on_null();
+            return true;
+        }
 
-		bool parse_boolean() {
-			skip_ws();
-			if (have(&Encoding::is_t)) {
-				expect(&Encoding::is_r, "expected 'true'");
-				expect(&Encoding::is_u, "expected 'true'");
-				expect(&Encoding::is_e, "expected 'true'");
-				callbacks.on_boolean(true);
-				return true;
-			}
-			if (have(&Encoding::is_f)) {
-				expect(&Encoding::is_a, "expected 'false'");
-				expect(&Encoding::is_l, "expected 'false'");
-				expect(&Encoding::is_s, "expected 'false'");
-				expect(&Encoding::is_e, "expected 'false'");
-				callbacks.on_boolean(false);
-				return true;
-			}
-			return false;
-		}
+        bool parse_boolean() {
+            skip_ws();
+            if (have(&Encoding::is_t)) {
+                expect(&Encoding::is_r, "expected 'true'");
+                expect(&Encoding::is_u, "expected 'true'");
+                expect(&Encoding::is_e, "expected 'true'");
+                callbacks.on_boolean(true);
+                return true;
+            }
+            if (have(&Encoding::is_f)) {
+                expect(&Encoding::is_a, "expected 'false'");
+                expect(&Encoding::is_l, "expected 'false'");
+                expect(&Encoding::is_s, "expected 'false'");
+                expect(&Encoding::is_e, "expected 'false'");
+                callbacks.on_boolean(false);
+                return true;
+            }
+            return false;
+        }
 
-		bool parse_number() {
-			skip_ws();
+        bool parse_number() {
+            skip_ws();
 
-			number_adapter adapter(callbacks, encoding, src.raw_cur());
-			bool started = false;
-			if (have(&Encoding::is_minus, adapter)) {
-				started = true;
-			}
-			if (!have(&Encoding::is_0, adapter) && !parse_int_part(adapter)) {
-				if (started) {
-					parse_error("expected digits after -");
-				}
-				return false;
-			}
-			parse_frac_part(adapter);
-			parse_exp_part(adapter);
-			adapter.finish();
-			return true;
-		}
+            number_adapter adapter(callbacks, encoding, src.raw_cur());
+            bool started = false;
+            if (have(&Encoding::is_minus, adapter)) {
+                started = true;
+            }
+            if (!have(&Encoding::is_0, adapter) && !parse_int_part(adapter)) {
+                if (started) {
+                    parse_error("expected digits after -");
+                }
+                return false;
+            }
+            parse_frac_part(adapter);
+            parse_exp_part(adapter);
+            adapter.finish();
+            return true;
+        }
 
-		bool parse_string() {
-			skip_ws();
+        bool parse_string() {
+            skip_ws();
 
-			if (!have(&Encoding::is_quote)) {
-				return false;
-			}
+            if (!have(&Encoding::is_quote)) {
+                return false;
+            }
 
-			callbacks.on_begin_string();
-			string_adapter adapter(callbacks, encoding, src.raw_cur());
-			while (!encoding.is_quote(need_cur("unterminated string"))) {
-				if (encoding.is_backslash(*src.raw_cur())) {
-					adapter.finish_run();
-					next();
-					parse_escape();
-					adapter.start_run();
-				} else {
-					adapter.process_codepoint(src.raw_end(),
-						boost::bind(&parser::parse_error,
+            callbacks.on_begin_string();
+            string_adapter adapter(callbacks, encoding, src.raw_cur());
+            while (!encoding.is_quote(need_cur("unterminated string"))) {
+                if (encoding.is_backslash(*src.raw_cur())) {
+                    adapter.finish_run();
+                    next();
+                    parse_escape();
+                    adapter.start_run();
+                } else {
+                    adapter.process_codepoint(src.raw_end(),
+                        boost::bind(&parser::parse_error,
                                     this, "invalid code sequence"));
-				}
-			}
-			adapter.finish_run();
-			callbacks.on_end_string();
-			next();
-			return true;
-		}
+                }
+            }
+            adapter.finish_run();
+            callbacks.on_end_string();
+            next();
+            return true;
+        }
 
-		bool parse_array() {
-			skip_ws();
+        bool parse_array() {
+            skip_ws();
 
-			if (!have(&Encoding::is_open_bracket)) {
-				return false;
-			}
+            if (!have(&Encoding::is_open_bracket)) {
+                return false;
+            }
 
-			callbacks.on_begin_array();
-			skip_ws();
-			if (have(&Encoding::is_close_bracket)) {
-				callbacks.on_end_array();
-				return true;
-			}
-			do {
-				parse_value();
-				skip_ws();
-			} while (have(&Encoding::is_comma));
-			expect(&Encoding::is_close_bracket, "expected ']' or ','");
-			callbacks.on_end_array();
-			return true;
-		}
+            callbacks.on_begin_array();
+            skip_ws();
+            if (have(&Encoding::is_close_bracket)) {
+                callbacks.on_end_array();
+                return true;
+            }
+            do {
+                parse_value();
+                skip_ws();
+            } while (have(&Encoding::is_comma));
+            expect(&Encoding::is_close_bracket, "expected ']' or ','");
+            callbacks.on_end_array();
+            return true;
+        }
 
-		bool parse_object() {
-			skip_ws();
+        bool parse_object() {
+            skip_ws();
 
-			if (!have(&Encoding::is_open_brace)) {
-				return false;
-			}
+            if (!have(&Encoding::is_open_brace)) {
+                return false;
+            }
 
-			callbacks.on_begin_object();
-			skip_ws();
-			if (have(&Encoding::is_close_brace)) {
-				callbacks.on_end_object();
-				return true;
-			}
-			do {
-				if (!parse_string()) {
-					parse_error("expected key string");
-				}
-				skip_ws();
-				expect(&Encoding::is_colon, "expected ':'");
-				parse_value();
-				skip_ws();
-			} while (have(&Encoding::is_comma));
-			expect(&Encoding::is_close_brace, "expected '}' or ','");
-			callbacks.on_end_object();
-			return true;
-		}
+            callbacks.on_begin_object();
+            skip_ws();
+            if (have(&Encoding::is_close_brace)) {
+                callbacks.on_end_object();
+                return true;
+            }
+            do {
+                if (!parse_string()) {
+                    parse_error("expected key string");
+                }
+                skip_ws();
+                expect(&Encoding::is_colon, "expected ':'");
+                parse_value();
+                skip_ws();
+            } while (have(&Encoding::is_comma));
+            expect(&Encoding::is_close_brace, "expected '}' or ','");
+            callbacks.on_end_object();
+            return true;
+        }
 
-	private:
-		typedef typename source::encoding_predicate encoding_predicate;
+    private:
+        typedef typename source::encoding_predicate encoding_predicate;
 
-		void parse_error(const char* msg) { src.parse_error(msg); }
-		void next() { src.next(); }
-		template <typename Action>
-		bool have(encoding_predicate p, Action& a) { return src.have(p, a); }
-		bool have(encoding_predicate p) { return src.have(p); }
-		template <typename Action>
-		void expect(encoding_predicate p, const char* msg, Action& a) {
-		    src.expect(p, msg, a);
-		}
-		void expect(encoding_predicate p, const char* msg) {
-		    src.expect(p, msg);
-		}
-		code_unit need_cur(const char* msg) { return src.need_cur(msg); }
+        void parse_error(const char* msg) { src.parse_error(msg); }
+        void next() { src.next(); }
+        template <typename Action>
+        bool have(encoding_predicate p, Action& a) { return src.have(p, a); }
+        bool have(encoding_predicate p) { return src.have(p); }
+        template <typename Action>
+        void expect(encoding_predicate p, const char* msg, Action& a) {
+            src.expect(p, msg, a);
+        }
+        void expect(encoding_predicate p, const char* msg) {
+            src.expect(p, msg);
+        }
+        code_unit need_cur(const char* msg) { return src.need_cur(msg); }
 
-		void skip_ws() {
-			while (have(&Encoding::is_ws)) {
-			}
-		}
+        void skip_ws() {
+            while (have(&Encoding::is_ws)) {
+            }
+        }
 
-		bool parse_int_part(number_adapter& action) {
-			if (!have(&Encoding::is_digit0, action)) {
-				return false;
-			}
-			parse_digits(action);
-			return true;
-		}
+        bool parse_int_part(number_adapter& action) {
+            if (!have(&Encoding::is_digit0, action)) {
+                return false;
+            }
+            parse_digits(action);
+            return true;
+        }
 
-		void parse_frac_part(number_adapter& action) {
-			if (!have(&Encoding::is_dot, action)) {
-				return;
-			}
-			expect(&Encoding::is_digit, "need at least one digit after '.'",
+        void parse_frac_part(number_adapter& action) {
+            if (!have(&Encoding::is_dot, action)) {
+                return;
+            }
+            expect(&Encoding::is_digit, "need at least one digit after '.'",
                    action);
-			parse_digits(action);
-		}
+            parse_digits(action);
+        }
 
-		void parse_exp_part(number_adapter& action) {
-			if (!have(&Encoding::is_eE, action)) {
-				return;
-			}
-			have(&Encoding::is_plusminus, action);
-			expect(&Encoding::is_digit, "need at least one digit in exponent",
+        void parse_exp_part(number_adapter& action) {
+            if (!have(&Encoding::is_eE, action)) {
+                return;
+            }
+            have(&Encoding::is_plusminus, action);
+            expect(&Encoding::is_digit, "need at least one digit in exponent",
                    action);
-			parse_digits(action);
-		}
+            parse_digits(action);
+        }
 
-		void parse_digits(number_adapter& action) {
-			while (have(&Encoding::is_digit, action)) {
-			}
-		}
+        void parse_digits(number_adapter& action) {
+            while (have(&Encoding::is_digit, action)) {
+            }
+        }
 
-		void parse_escape() {
-			if (have(&Encoding::is_quote)) {
-				feed(0x22);
-			} else if (have(&Encoding::is_backslash)) {
-				feed(0x5c);
-			} else if (have(&Encoding::is_slash)) {
-				feed(0x2f);
-			} else if (have(&Encoding::is_b)) {
-				feed(0x08); // backspace
-			} else if (have(&Encoding::is_f)) {
-				feed(0x0c); // formfeed
-			} else if (have(&Encoding::is_n)) {
-				feed(0x0a); // line feed
-			} else if (have(&Encoding::is_r)) {
-				feed(0x0d); // carriage return
-			} else if (have(&Encoding::is_t)) {
-				feed(0x09); // horizontal tab
-			} else if (have(&Encoding::is_u)) {
-				parse_codepoint_ref();
-			} else {
-				parse_error("invalid escape sequence");
-			}
-		}
+        void parse_escape() {
+            if (have(&Encoding::is_quote)) {
+                feed(0x22);
+            } else if (have(&Encoding::is_backslash)) {
+                feed(0x5c);
+            } else if (have(&Encoding::is_slash)) {
+                feed(0x2f);
+            } else if (have(&Encoding::is_b)) {
+                feed(0x08); // backspace
+            } else if (have(&Encoding::is_f)) {
+                feed(0x0c); // formfeed
+            } else if (have(&Encoding::is_n)) {
+                feed(0x0a); // line feed
+            } else if (have(&Encoding::is_r)) {
+                feed(0x0d); // carriage return
+            } else if (have(&Encoding::is_t)) {
+                feed(0x09); // horizontal tab
+            } else if (have(&Encoding::is_u)) {
+                parse_codepoint_ref();
+            } else {
+                parse_error("invalid escape sequence");
+            }
+        }
 
-		unsigned parse_hex_quad() {
-			unsigned codepoint = 0;
-			for (int i = 0; i < 4; ++i) {
-				int value = encoding.decode_hexdigit(
-				    need_cur("invalid escape sequence"));
-				if (value < 0) {
-					parse_error("invalid escape sequence");
-				}
-				codepoint *= 16;
-				codepoint += value;
-				next();
-			}
-			return codepoint;
-		}
+        unsigned parse_hex_quad() {
+            unsigned codepoint = 0;
+            for (int i = 0; i < 4; ++i) {
+                int value = encoding.decode_hexdigit(
+                    need_cur("invalid escape sequence"));
+                if (value < 0) {
+                    parse_error("invalid escape sequence");
+                }
+                codepoint *= 16;
+                codepoint += value;
+                next();
+            }
+            return codepoint;
+        }
 
-		static bool is_surrogate_high(unsigned codepoint) {
-			return (codepoint & 0xfc00) == 0xd800;
-		}
-		static bool is_surrogate_low(unsigned codepoint) {
-			return (codepoint & 0xfc00) == 0xdc00;
-		}
-		static unsigned combine_surrogates(unsigned high, unsigned low) {
-			return 0x010000 + (((high & 0x3ff) << 10) | (low & 0x3ff));
-		}
+        static bool is_surrogate_high(unsigned codepoint) {
+            return (codepoint & 0xfc00) == 0xd800;
+        }
+        static bool is_surrogate_low(unsigned codepoint) {
+            return (codepoint & 0xfc00) == 0xdc00;
+        }
+        static unsigned combine_surrogates(unsigned high, unsigned low) {
+            return 0x010000 + (((high & 0x3ff) << 10) | (low & 0x3ff));
+        }
 
-		void parse_codepoint_ref() {
-			unsigned codepoint = parse_hex_quad();
-			if (is_surrogate_low(codepoint)) {
-				parse_error("invalid codepoint, stray low surrogate");
-			}
-			if (is_surrogate_high(codepoint)) {
-				expect(&Encoding::is_backslash,
-				    "invalid codepoint, stray high surrogate");
-				expect(&Encoding::is_u,
-				    "expected codepoint reference after high surrogate");
-				int low = parse_hex_quad();
-				if (!is_surrogate_low(low)) {
-					parse_error("expected low surrogate after high surrogate");
-				}
-				codepoint = combine_surrogates(codepoint, low);
-			}
-			feed(codepoint);
-		}
+        void parse_codepoint_ref() {
+            unsigned codepoint = parse_hex_quad();
+            if (is_surrogate_low(codepoint)) {
+                parse_error("invalid codepoint, stray low surrogate");
+            }
+            if (is_surrogate_high(codepoint)) {
+                expect(&Encoding::is_backslash,
+                    "invalid codepoint, stray high surrogate");
+                expect(&Encoding::is_u,
+                    "expected codepoint reference after high surrogate");
+                int low = parse_hex_quad();
+                if (!is_surrogate_low(low)) {
+                    parse_error("expected low surrogate after high surrogate");
+                }
+                codepoint = combine_surrogates(codepoint, low);
+            }
+            feed(codepoint);
+        }
 
-		void feed(unsigned codepoint) {
-			encoding.feed_codepoint(codepoint,
+        void feed(unsigned codepoint) {
+            encoding.feed_codepoint(codepoint,
                                     boost::bind(&Callbacks::on_code_unit,
                                                 boost::ref(callbacks), _1));
-		}
+        }
 
-		Callbacks& callbacks;
-		Encoding& encoding;
-		source src;
-	};
+        Callbacks& callbacks;
+        Encoding& encoding;
+        source src;
+    };
 
 }}}}
 

--- a/include/boost/property_tree/detail/json_parser/parser.hpp
+++ b/include/boost/property_tree/detail/json_parser/parser.hpp
@@ -3,6 +3,7 @@
 
 #include <boost/property_tree/detail/json_parser_error.hpp>
 
+#include <boost/ref.hpp>
 #include <boost/bind.hpp>
 #include <boost/format.hpp>
 

--- a/include/boost/property_tree/detail/json_parser/standard_callbacks.hpp
+++ b/include/boost/property_tree/detail/json_parser/standard_callbacks.hpp
@@ -116,6 +116,7 @@ namespace boost { namespace property_tree {
                 return *stack.back().t;
             }
             case object:
+            default:
                 assert(false); // must start with string, i.e. call new_value
             case key: {
                 l.t->push_back(std::make_pair(key_buffer, Ptree()));
@@ -128,7 +129,6 @@ namespace boost { namespace property_tree {
                 stack.pop_back();
                 return new_tree();
             }
-            assert(false);
         }
         string& new_value() {
             if (stack.empty()) return new_tree().data();

--- a/include/boost/property_tree/detail/json_parser/standard_callbacks.hpp
+++ b/include/boost/property_tree/detail/json_parser/standard_callbacks.hpp
@@ -1,6 +1,7 @@
 #ifndef BOOST_PROPERTY_TREE_DETAIL_JSON_PARSER_STANDARD_CALLBACKS_HPP
 #define BOOST_PROPERTY_TREE_DETAIL_JSON_PARSER_STANDARD_CALLBACKS_HPP
 
+#include <boost/assert.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <vector>
 
@@ -117,7 +118,7 @@ namespace boost { namespace property_tree {
             }
             case object:
             default:
-                assert(false); // must start with string, i.e. call new_value
+                BOOST_ASSERT(false); // must start with string, i.e. call new_value
             case key: {
                 l.t->push_back(std::make_pair(key_buffer, Ptree()));
                 l.k = object;

--- a/include/boost/property_tree/detail/json_parser/wide_encoding.hpp
+++ b/include/boost/property_tree/detail/json_parser/wide_encoding.hpp
@@ -1,9 +1,9 @@
 #ifndef BOOST_PROPERTY_TREE_DETAIL_JSON_PARSER_WIDE_ENCODING_HPP
 #define BOOST_PROPERTY_TREE_DETAIL_JSON_PARSER_WIDE_ENCODING_HPP
 
+#include <boost/assert.hpp>
 #include <boost/range/iterator_range_core.hpp>
 
-#include <cassert>
 #include <utility>
 
 namespace boost { namespace property_tree {
@@ -72,7 +72,7 @@ namespace boost { namespace property_tree {
         }
 
         wchar_t to_internal_trivial(wchar_t c) const {
-            assert(!is_surrogate_high(c) && !is_surrogate_low(c));
+            BOOST_ASSERT(!is_surrogate_high(c) && !is_surrogate_low(c));
             return c;
         }
 

--- a/include/boost/property_tree/detail/ptree_utils.hpp
+++ b/include/boost/property_tree/detail/ptree_utils.hpp
@@ -57,7 +57,7 @@ namespace boost { namespace property_tree { namespace detail
     template<typename Str>
     Str widen(const char *text)
     {
-	Str result;
+        Str result;
         while (*text)
         {
             result += typename Str::value_type(*text);
@@ -70,7 +70,7 @@ namespace boost { namespace property_tree { namespace detail
     template<typename Str, typename char_type>
     Str narrow(const char_type *text)
     {
-	Str result;
+        Str result;
         while (*text)
         {
             if (*text < 0 || *text > (std::numeric_limits<char>::max)())

--- a/include/boost/property_tree/detail/xml_parser_utils.hpp
+++ b/include/boost/property_tree/detail/xml_parser_utils.hpp
@@ -23,8 +23,8 @@ namespace boost { namespace property_tree { namespace xml_parser
     template<class Str>
     Str condense(const Str &s)
     {
-	typedef typename Str::value_type Ch;
-	Str r;
+        typedef typename Str::value_type Ch;
+        Str r;
         std::locale loc;
         bool space = false;
         typename Str::const_iterator end = s.end();
@@ -78,11 +78,11 @@ namespace boost { namespace property_tree { namespace xml_parser
         }
         return r;
     }
-    
+
     template<class Str>
     Str decode_char_entities(const Str &s)
     {
-	typedef typename Str::value_type Ch;
+        typedef typename Str::value_type Ch;
         Str r;
         typename Str::const_iterator end = s.end();
         for (typename Str::const_iterator it = s.begin(); it != end; ++it)
@@ -107,7 +107,7 @@ namespace boost { namespace property_tree { namespace xml_parser
         }
         return r;
     }
-    
+
     template<class Str>
     const Str &xmldecl()
     {

--- a/include/boost/property_tree/detail/xml_parser_write.hpp
+++ b/include/boost/property_tree/detail/xml_parser_write.hpp
@@ -36,7 +36,7 @@ namespace boost { namespace property_tree { namespace xml_parser
                            const xml_writer_settings<Str> & settings
                            )
     {
-	typedef typename Str::value_type Ch;
+        typedef typename Str::value_type Ch;
         if (separate_line)
             write_xml_indent(stream,indent,settings);
         stream << Ch('<') << Ch('!') << Ch('-') << Ch('-');
@@ -45,7 +45,7 @@ namespace boost { namespace property_tree { namespace xml_parser
         if (separate_line)
             stream << Ch('\n');
     }
-    
+
     template<class Str>
     void write_xml_text(std::basic_ostream<typename Str::value_type> &stream,
                         const Str &s,
@@ -54,8 +54,8 @@ namespace boost { namespace property_tree { namespace xml_parser
                         const xml_writer_settings<Str> & settings
                         )
     {
-	typedef typename Str::value_type Ch;
-        if (separate_line)    
+        typedef typename Str::value_type Ch;
+        if (separate_line)
             write_xml_indent(stream,indent,settings);
         stream << encode_char_entities(s);
         if (separate_line)
@@ -63,9 +63,9 @@ namespace boost { namespace property_tree { namespace xml_parser
     }
 
     template<class Ptree>
-    void write_xml_element(std::basic_ostream<typename Ptree::key_type::value_type> &stream, 
+    void write_xml_element(std::basic_ostream<typename Ptree::key_type::value_type> &stream,
                            const typename Ptree::key_type &key,
-                           const Ptree &pt, 
+                           const Ptree &pt,
                            int indent,
                            const xml_writer_settings<typename Ptree::key_type> & settings)
     {
@@ -89,7 +89,7 @@ namespace boost { namespace property_tree { namespace xml_parser
                 }
             }
         }
-        
+
         // Write element
         if (pt.data().empty() && pt.empty())    // Empty key
         {
@@ -104,11 +104,9 @@ namespace boost { namespace property_tree { namespace xml_parser
         }
         else    // Nonempty key
         {
-        
             // Write opening tag, attributes and data
             if (indent >= 0)
             {
-            
                 // Write opening brace and key
                 write_xml_indent(stream,indent,settings);
                 stream << Ch('<') << key;
@@ -163,7 +161,7 @@ namespace boost { namespace property_tree { namespace xml_parser
                     write_xml_element(stream, it->first, it->second,
                         indent + 1, settings);
             }
-            
+
             // Write closing tag
             if (indent >= 0 && !has_attrs_only)
             {

--- a/include/boost/property_tree/detail/xml_parser_writer_settings.hpp
+++ b/include/boost/property_tree/detail/xml_parser_writer_settings.hpp
@@ -16,12 +16,12 @@
 
 namespace boost { namespace property_tree { namespace xml_parser
 {
-    
+
     // Naively convert narrow string to another character type
     template<class Str>
     Str widen(const char *text)
     {
-	typedef typename Str::value_type Ch;
+        typedef typename Str::value_type Ch;
         Str result;
         while (*text)
         {
@@ -35,7 +35,7 @@ namespace boost { namespace property_tree { namespace xml_parser
     template<class Str>
     class xml_writer_settings
     {
-	typedef typename Str::value_type Ch;
+        typedef typename Str::value_type Ch;
     public:
         xml_writer_settings(Ch inchar = Ch(' '),
                 typename Str::size_type incount = 0,


### PR DESCRIPTION
The pull request does the following fixes:

- Silences gcc warnings "control reaches end of non-void function"
- Ports code to `BOOST_ASSERT` instead of plain `assert`.
- Adds a few missing includes.
- Converts tabs to spaces.
