### PR TITLE
Fix bug #11600. Remove whitespace in empty XML nodes.

### DIFF
--- a/include/boost/property_tree/detail/rapidxml.hpp
+++ b/include/boost/property_tree/detail/rapidxml.hpp
@@ -2167,12 +2167,25 @@ namespace boost { namespace property_tree { namespace detail {namespace rapidxml
             // For all children and text
             while (1)
             {
-                // Skip whitespace between > and node contents
-                Ch *contents_start = text;      // Store start of node contents before whitespace is skipped
-                if (Flags & parse_trim_whitespace)
-                    skip<whitespace_pred, Flags>(text);
-                Ch next_char = *text;
+                // Skip whitespace between > and node contents in case of trim_whitespace and in case there
+                // is no non-whitespace content at all in between "<ELEMENT>XXX<subelement>" (i.e. XXX is only
+                // whitespace)
 
+                Ch *contents_start = text;      // Store start of node contents before whitespace is skipped
+                skip<whitespace_pred, Flags>(text);
+
+                Ch next_char = *text;
+                if (!(Flags & parse_trim_whitespace))
+                {
+                    if (next_char != '<')
+                    {
+                        text = contents_start;
+                    }
+                    // The else case is the case where only whitespace and other subelements exist.
+                    // We have to delete whitespace, even when trim_whitespace is off
+                    // otherwise we will have exponentially growing newlines in the XML in case of
+                    // neither trim_whitespace or normalize_whitespace
+                }
             // After data nodes, instead of continuing the loop, control jumps here.
             // This is because zero termination inside parse_and_append_data() function
             // would wreak havoc with the above code.


### PR DESCRIPTION
This pull request was already submitted as a patch in Bug report #11600. An explanation of what it does together with testcode can be found there:
https://svn.boost.org/trac/boost/ticket/11600

It does not change the handling of "\t" and "\n" in Text nodes as discussed in the bug report mentioned under "Change of existing behaviour - second bug", even though I really think it should be changed. If requested, I can immediately send another pull request also fixing this.