### PR TITLE
Allow json parser to output typed values.

### DIFF
--- a/include/boost/property_tree/detail/json_parser_write.hpp
+++ b/include/boost/property_tree/detail/json_parser_write.hpp
@@ -182,7 +182,6 @@ namespace boost { namespace property_tree { namespace json_parser
         if (!verify_json(pt, 0))
             BOOST_PROPERTY_TREE_THROW(json_parser_error("ptree contains data that cannot be represented in JSON format", filename, 0));
         write_json_helper(stream, pt, 0, pretty);
-        stream << std::endl;
         if (!stream.good())
             BOOST_PROPERTY_TREE_THROW(json_parser_error("write error", filename, 0));
     }

--- a/include/boost/property_tree/detail/json_parser_write.hpp
+++ b/include/boost/property_tree/detail/json_parser_write.hpp
@@ -65,7 +65,7 @@ namespace boost { namespace property_tree { namespace json_parser
     }
 
     template<class Ptree>
-    void write_json_helper(std::basic_ostream<typename Ptree::key_type::value_type> &stream, 
+    void write_json_helper(std::basic_ostream<typename Ptree::key_type::value_type> &stream,
                            const Ptree &pt,
                            int indent, bool pretty)
     {
@@ -78,8 +78,32 @@ namespace boost { namespace property_tree { namespace json_parser
         {
             // Write value
             Str data = create_escapes(pt.template get_value<Str>());
-            stream << Ch('"') << data << Ch('"');
 
+            bool is_string = true;
+            //Try to cast to a number
+            {
+                std::basic_istringstream<Ch> iss(data);
+                long double value;
+                if (!(!(iss >> value) || !iss.eof()))
+                {
+                    is_string = false;
+                    stream << data;
+                }
+            }
+            //Try with a boolean
+            if (data == "true")
+            {
+                is_string = false;
+                stream << data;
+            }
+            if (data == "false")
+            {
+                is_string = false;
+                stream << data;
+            }
+            //Display as a string
+            if (is_string)
+                stream << Ch('"') << data << Ch('"');
         }
         else if (indent > 0 && pt.count(Str()) == pt.size())
         {

--- a/include/boost/property_tree/detail/json_parser_write.hpp
+++ b/include/boost/property_tree/detail/json_parser_write.hpp
@@ -101,6 +101,11 @@ namespace boost { namespace property_tree { namespace json_parser
                 is_string = false;
                 stream << data;
             }
+            if (data == "null")
+            {
+                is_string = false;
+                stream << data;
+            }
             //Display as a string
             if (is_string)
                 stream << Ch('"') << data << Ch('"');


### PR DESCRIPTION
Hi,

This is a short patch that allow writing typed value in json, a "bug" issued more than 4 years ago (see http://stackoverflow.com/questions/2855741/why-boost-property-tree-write-json-saves-everything-as-string-is-it-possible-to ) .

Feel free to patch the patch as much as you want.

Nb : This patch isn't perfect. Since ptree doesn't store data type, all typed values wrapped around string will be written typed, and there is no way to prevent that. But it's still nicer than storing everything in strings.

Regards,

Edit : I added a patch asked 6 years ago : https://svn.boost.org/trac/boost/ticket/3828 Removing a trailing std::endl line.