### PR TITLE
Added new trim_whitespace_without_normalization option

### DIFF
--- a/include/boost/property_tree/detail/xml_parser_flags.hpp
+++ b/include/boost/property_tree/detail/xml_parser_flags.hpp
@@ -20,10 +20,16 @@ namespace boost { namespace property_tree { namespace xml_parser
     static const int no_comments     = 0x2;
     /// Whitespace should be collapsed and trimmed.
     static const int trim_whitespace = 0x4;
+    /// Whitespace should only be trimmed.
+    static const int trim_whitespace_without_normalization = 0x8;
 
     inline bool validate_flags(int flags)
     {
-        return (flags & ~(no_concat_text | no_comments | trim_whitespace)) == 0;
+        return (flags & ~(no_concat_text
+                        | no_comments
+                        | trim_whitespace
+                        | trim_whitespace_without_normalization
+                          )) == 0;
     }
 
 } } }

--- a/include/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
+++ b/include/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
@@ -103,6 +103,9 @@ namespace boost { namespace property_tree { namespace xml_parser
 
         try {
             // Parse using appropriate flags
+            const int f_tws_n = parse_trim_whitespace;
+            const int f_tws_n_c = parse_trim_whitespace
+                                | parse_comment_nodes;
             const int f_tws = parse_normalize_whitespace
                             | parse_trim_whitespace;
             const int f_c = parse_comment_nodes;
@@ -114,13 +117,21 @@ namespace boost { namespace property_tree { namespace xml_parser
             if (flags & no_comments) {
                 if (flags & trim_whitespace)
                     doc.BOOST_NESTED_TEMPLATE parse<f_tws>(&v.front());
-                else
-                    doc.BOOST_NESTED_TEMPLATE parse<0>(&v.front());
+                else  {
+                    if (flags & trim_whitespace_without_normalization)
+                        doc.BOOST_NESTED_TEMPLATE parse<f_tws_n>(&v.front());
+                    else
+                        doc.BOOST_NESTED_TEMPLATE parse<0>(&v.front());
+                }
             } else {
                 if (flags & trim_whitespace)
                     doc.BOOST_NESTED_TEMPLATE parse<f_tws_c>(&v.front());
-                else
-                    doc.BOOST_NESTED_TEMPLATE parse<f_c>(&v.front());
+                else {
+                    if (flags & trim_whitespace_without_normalization)
+                        doc.BOOST_NESTED_TEMPLATE parse<f_tws_n_c>(&v.front());
+                    else
+                        doc.BOOST_NESTED_TEMPLATE parse<f_c>(&v.front());
+                }
             }
 
             // Create ptree from nodes

--- a/include/boost/property_tree/xml_parser.hpp
+++ b/include/boost/property_tree/xml_parser.hpp
@@ -41,6 +41,8 @@ namespace boost { namespace property_tree { namespace xml_parser
      * @li @c no_comments -- Skip XML comments.
      * @li @c trim_whitespace -- Trim leading and trailing whitespace from text,
      *                           and collapse sequences of whitespace.
+     * @li @c trim_whitespace_without_normalization -- Trim leading and trailing
+     *                           whitespace from text.
      */
     template<class Ptree>
     void read_xml(std::basic_istream<


### PR DESCRIPTION
Following our discussion here: https://svn.boost.org/trac/boost/ticket/11600#comment:6
I implemented a new flag trim_whitespace_without_normalization, which enables rapidxml::parse_trim_whitespace without enabling rapidxml::normalize_whitespace .

This option allows preserving whitespace in textnodes and pretty printing of XML at the same time (and clean roundtrips of those).

If both "boost::property_tree::xml_parser::trim_whitespace" and "boost::property_tree::xml_parser::trim_whitespace_without_normalization" are given "trim_whitespace" overrides "trim_whitespace_without_normalization". Existing behaviour of the library is not modified.