### PR TITLE
Fix write_json non-pretty print extra endl

### DIFF
--- a/include/boost/property_tree/json_parser/detail/write.hpp
+++ b/include/boost/property_tree/json_parser/detail/write.hpp
@@ -158,7 +158,10 @@ namespace boost { namespace property_tree { namespace json_parser
         if (!verify_json(pt, 0))
             BOOST_PROPERTY_TREE_THROW(json_parser_error("ptree contains data that cannot be represented in JSON format", filename, 0));
         write_json_helper(stream, pt, 0, pretty);
-        stream << std::endl;
+
+        if (pretty) stream << std::endl;
+        else stream << std::flush;
+
         if (!stream.good())
             BOOST_PROPERTY_TREE_THROW(json_parser_error("write error", filename, 0));
     }

--- a/test/test_json_parser.cpp
+++ b/test/test_json_parser.cpp
@@ -257,7 +257,7 @@ const char *bug_data_pr7180_1 =
     "    ]\n"
     "}\n";
 const char *bug_data_pr7180_2 =
-    "{\"a\":[\"1\",\"2\"]}\n";
+    "{\"a\":[\"1\",\"2\"]}";
 
 struct ReadFunc
 {


### PR DESCRIPTION
According to bug #12149, the non-pretty version of write_json should not
print the trailing endl.  This patch only prints the endl in the pretty
case, and only does the flush component of the endl in the non-pretty
version.

Signed-off-by: Erich Keane erich.keane@intel.com
