### PR TITLE
Enhanced xml pretty printing with nodes having attributes only.

### DIFF
--- a/include/boost/property_tree/detail/xml_parser_write.hpp
+++ b/include/boost/property_tree/detail/xml_parser_write.hpp
@@ -113,12 +113,31 @@ namespace boost { namespace property_tree { namespace xml_parser
 
                 // Write attributes
                 if (optional<const Ptree &> attribs = pt.get_child_optional(xmlattr<Str>()))
+                {
                     for (It it = attribs.get().begin(); it != attribs.get().end(); ++it)
-                        stream << Ch(' ') << it->first << Ch('=')
-                               << Ch('"')
-                               << encode_char_entities(
-                                    it->second.template get_value<Str>())
-                               << Ch('"');
+                    {
+                        if (want_pretty && has_attrs_only)
+                        {
+                            stream << Ch('\n');
+                            write_xml_indent(stream,indent+1,settings);
+                        }
+                        else
+                        {
+                            stream << Ch(' ');
+                        }
+
+                        stream << it->first << Ch('=')
+                        << Ch('"')
+                        << encode_char_entities(
+                            it->second.template get_value<Str>())
+                        << Ch('"');
+                    }
+                    if (want_pretty && has_attrs_only)
+                    {
+                        stream << Ch('\n');
+                        write_xml_indent(stream,indent,settings);
+                    }
+                }
 
                 if ( has_attrs_only )
                 {


### PR DESCRIPTION
Each attribute is printed in a separate, indented line now.
This makes the xml better readable, especially if there are many attributes in the node.

Signed-off-by: e-driver <e-driver@t-online.de>