### PR TITLE
Fix Wcovered-switch-default warning

### DIFF
--- a/include/boost/property_tree/json_parser/detail/standard_callbacks.hpp
+++ b/include/boost/property_tree/json_parser/detail/standard_callbacks.hpp
@@ -117,7 +117,6 @@ namespace boost { namespace property_tree {
                 return *stack.back().t;
             }
             case object:
-            default:
                 BOOST_ASSERT(false); // must start with string, i.e. call new_value
             case key: {
                 l.t->push_back(std::make_pair(key_buffer, Ptree()));
@@ -130,6 +129,7 @@ namespace boost { namespace property_tree {
                 stack.pop_back();
                 return new_tree();
             }
+            BOOST_ASSERT(false);
         }
         string& new_value() {
             if (stack.empty()) return new_tree().data();


### PR DESCRIPTION
On clang with -Wcovered-switch-default this fixes the following error:
`/mnt/fscratch0/pub/dependencies/boost/boost/property_tree/json_parser/detail/standard_callbacks.hpp:130:6: error: default label in switch which covers all enumeration values [-Werror,-Wcovered-switch-default]
            default:`

Essentially default is unnecessary and may prevent detection of future bugs by allowing catching future added enums.  This moves the Assert to the bottom of the function where it theoretically is dead code as the enum is fully covered by returns.