### PR TITLE
Proof-of-concept `splice` operation

### DIFF
--- a/include/boost/property_tree/detail/ptree_implementation.hpp
+++ b/include/boost/property_tree/detail/ptree_implementation.hpp
@@ -879,6 +879,11 @@ namespace boost { namespace property_tree
                    typename translator_between<data_type, Type>::type());
     }
 
+    template<class K, class D, class C>
+    void basic_ptree<K, D, C>::splice(const_iterator position, self_type& other)
+    {
+        subs::ch(this).splice(position.base(), subs::ch(&other));
+    }
 
     template<class K, class D, class C>
     basic_ptree<K, D, C> *

--- a/include/boost/property_tree/ptree.hpp
+++ b/include/boost/property_tree/ptree.hpp
@@ -486,6 +486,13 @@ namespace boost { namespace property_tree
         template<class Type>
         self_type &add(const path_type &path, const Type &value);
 
+        /** Proof Of Concept splice operation
+         * Author: Seth Heeren
+         * Documentation TODO, additional overloads
+         *
+         * reviewer suggestion: Joaquín M López Muñoz
+         */
+        void splice(const_iterator position, self_type& other);
     private:
         // Hold the data of this node
         data_type m_data;


### PR DESCRIPTION
It's currently not possible to efficiently move nodes between ptrees.

Context/discussion: https://stackoverflow.com/a/29563086/85371

This PR is a **DRAFT**. It is meant to sollicit interest and quick review (is the idea "sane"? I do not believe any invariants are at risk, but maybe the core maintainers see more).

If there's interest, I'll flesh it out in full.

-----

Multi Index splice overloads: http://www.boost.org/doc/libs/release/libs/multi_index/doc/reference/seq_indices.html#list_operations

reviewer suggestion: Joaquín M López Muñoz