### PR TITLE
isspace() may not be a macro

### DIFF
--- a/include/boost/property_tree/detail/info_parser_read.hpp
+++ b/include/boost/property_tree/detail/info_parser_read.hpp
@@ -70,7 +70,7 @@ namespace boost { namespace property_tree { namespace info_parser
         unsigned n = c;
         if (n > 127)
             return false;
-        return std::isspace(c) != 0;
+        return isspace(c) != 0;
     }
 
     // Advance pointer past whitespace

--- a/include/boost/property_tree/detail/info_parser_read.hpp
+++ b/include/boost/property_tree/detail/info_parser_read.hpp
@@ -66,6 +66,7 @@ namespace boost { namespace property_tree { namespace info_parser
     bool is_ascii_space(Ch c)
     {
         // Everything outside ASCII is not space.
+        using namespace std;
         unsigned n = c;
         if (n > 127)
             return false;


### PR DESCRIPTION
Specifically in Dinkum clib shipped with VxWorks it's an inline function