### PR TITLE
Fix bug #13565. Compile issue on VS 2017 15.7.

### DIFF
--- a/include/boost/property_tree/detail/ptree_implementation.hpp
+++ b/include/boost/property_tree/detail/ptree_implementation.hpp
@@ -109,7 +109,7 @@ namespace boost { namespace property_tree
     };
     template <class K, class D, class C>
     class basic_ptree<K, D, C>::reverse_iterator
-        : public boost::reverse_iterator<iterator>
+        : public boost::reverse_iterator<basic_ptree<K, D, C>::iterator>
     {
     public:
         reverse_iterator() {}
@@ -119,7 +119,7 @@ namespace boost { namespace property_tree
     };
     template <class K, class D, class C>
     class basic_ptree<K, D, C>::const_reverse_iterator
-        : public boost::reverse_iterator<const_iterator>
+        : public boost::reverse_iterator<basic_ptree<K, D, C>::const_iterator>
     {
     public:
         const_reverse_iterator() {}

--- a/include/boost/property_tree/detail/ptree_implementation.hpp
+++ b/include/boost/property_tree/detail/ptree_implementation.hpp
@@ -109,7 +109,7 @@ namespace boost { namespace property_tree
     };
     template <class K, class D, class C>
     class basic_ptree<K, D, C>::reverse_iterator
-        : public boost::reverse_iterator<basic_ptree<K, D, C>::iterator>
+        : public boost::reverse_iterator<typename basic_ptree<K, D, C>::iterator>
     {
     public:
         reverse_iterator() {}
@@ -119,7 +119,7 @@ namespace boost { namespace property_tree
     };
     template <class K, class D, class C>
     class basic_ptree<K, D, C>::const_reverse_iterator
-        : public boost::reverse_iterator<basic_ptree<K, D, C>::const_iterator>
+        : public boost::reverse_iterator<typename basic_ptree<K, D, C>::const_iterator>
     {
     public:
         const_reverse_iterator() {}


### PR DESCRIPTION
Prefix the template parameter to make them fully qualified, to overcome any issue with wrong naming resolution.