### PR TITLE
Link to wikipedia description of INI file fixed.

### DIFF
--- a/doc/ini_parser.qbk
+++ b/doc/ini_parser.qbk
@@ -6,7 +6,7 @@
  / file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
  /]
 [section INI Parser]
-[def __ini__ [@http://en.wikipedia.org/wiki/INI INI format]]
+[def __ini__ [@https://en.wikipedia.org/wiki/INI_file INI format]]
 The __ini__ was once widely used in the world of Windows. It is now deprecated,
 but is still used by a surprisingly large number of applications. The reason is
 probably its simplicity, plus that Microsoft recommends using the registry as


### PR DESCRIPTION
Replaced wikipedia link that pointed to the disambiguation page [https://en.wikipedia.org/wiki/INI](https://en.wikipedia.org/wiki/INI) by actual link to the article INI file [https://en.wikipedia.org/wiki/INI_file](https://en.wikipedia.org/wiki/INI_file).