### PR TITLE
Fix usage of deprecated Boost.Bind features

### DIFF
--- a/include/boost/property_tree/json_parser/detail/parser.hpp
+++ b/include/boost/property_tree/json_parser/detail/parser.hpp
@@ -3,8 +3,8 @@
 
 #include <boost/property_tree/json_parser/error.hpp>
 
-#include <boost/ref.hpp>
-#include <boost/bind.hpp>
+#include <boost/core/ref.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/format.hpp>
 
 #include <iterator>
@@ -214,7 +214,7 @@ namespace boost { namespace property_tree {
         void process_codepoint(Sentinel end, EncodingErrorFn error_fn) {
             encoding.transcode_codepoint(cur, end,
                 boost::bind(&Callbacks::on_code_unit,
-                            boost::ref(callbacks), _1),
+                            boost::ref(callbacks), boost::placeholders::_1),
                 error_fn);
         }
 
@@ -517,7 +517,7 @@ namespace boost { namespace property_tree {
         void feed(unsigned codepoint) {
             encoding.feed_codepoint(codepoint,
                                     boost::bind(&Callbacks::on_code_unit,
-                                                boost::ref(callbacks), _1));
+                                                boost::ref(callbacks), boost::placeholders::_1));
         }
 
         Callbacks& callbacks;


### PR DESCRIPTION
This fixes deprecation warnings generated by `boost/bind.hpp`.

Also, use a more actual include path for `ref.hpp`.