### PR TITLE
Use non-deprecated bind/bind.hpp header and non-globals placeholders

### DIFF
--- a/include/boost/property_tree/json_parser/detail/parser.hpp
+++ b/include/boost/property_tree/json_parser/detail/parser.hpp
@@ -4,7 +4,7 @@
 #include <boost/property_tree/json_parser/error.hpp>
 
 #include <boost/ref.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/format.hpp>
 
 #include <iterator>
@@ -517,7 +517,7 @@ namespace boost { namespace property_tree {
         void feed(unsigned codepoint) {
             encoding.feed_codepoint(codepoint,
                                     boost::bind(&Callbacks::on_code_unit,
-                                                boost::ref(callbacks), _1));
+                                                boost::ref(callbacks), boost::placeholders::_1));
         }
 
         Callbacks& callbacks;


### PR DESCRIPTION
boost\bind.hpp is deprecated and recommends using boost\bind\bind.hpp instead, see: https://github.com/boostorg/bind/blob/develop/include/boost/bind.hpp
