### PR TITLE
Improve to be able to use std::optional optionally

### DIFF
--- a/include/boost/property_tree/detail/optional_type.hpp
+++ b/include/boost/property_tree/detail/optional_type.hpp
@@ -1,0 +1,22 @@
+#ifndef BOOST_PROPERTY_TREE_DETAIL_OPTIONAL_TYPE_HPP_INCLUDED
+#define BOOST_PROPERTY_TREE_DETAIL_OPTIONAL_TYPE_HPP_INCLUDED
+
+#if defined(BOOST_PROPERTY_TREE_USE_STD_OPTIONAL)
+#  include <optional>
+#else
+#  include <boost/optional.hpp>
+#endif
+
+namespace boost { namespace property_tree {
+
+#if defined(BOOST_PROPERTY_TREE_USE_STD_OPTIONAL)
+    template <class T>
+    using optional = std::optional<T>;
+#else
+    template <class T>
+    using optional = boost::optional<T>;
+#endif
+
+}}
+
+#endif

--- a/include/boost/property_tree/detail/ptree_implementation.hpp
+++ b/include/boost/property_tree/detail/ptree_implementation.hpp
@@ -664,7 +664,7 @@ namespace boost { namespace property_tree
     typename boost::enable_if<detail::is_translator<Translator>, Type>::type
     basic_ptree<K, D, C>::get_value(Translator tr) const
     {
-        if(boost::optional<Type> o = get_value_optional<Type>(tr)) {
+        if(optional<Type> o = get_value_optional<Type>(tr)) {
             return *o;
         }
         BOOST_PROPERTY_TREE_THROW(ptree_bad_data(

--- a/include/boost/property_tree/id_translator.hpp
+++ b/include/boost/property_tree/id_translator.hpp
@@ -12,8 +12,8 @@
 #define BOOST_PROPERTY_TREE_ID_TRANSLATOR_HPP_INCLUDED
 
 #include <boost/property_tree/ptree_fwd.hpp>
+#include <boost/property_tree/detail/optional_type.hpp>
 
-#include <boost/optional.hpp>
 #include <string>
 
 namespace boost { namespace property_tree
@@ -26,8 +26,8 @@ namespace boost { namespace property_tree
         typedef T internal_type;
         typedef T external_type;
 
-        boost::optional<T> get_value(const T &v) { return v; }
-        boost::optional<T> put_value(const T &v) { return v; }
+        optional<T> get_value(const T &v) { return v; }
+        optional<T> put_value(const T &v) { return v; }
     };
 
     // This is the default translator whenever you get two equal types.

--- a/include/boost/property_tree/ptree.hpp
+++ b/include/boost/property_tree/ptree.hpp
@@ -17,6 +17,7 @@
 #include <boost/property_tree/stream_translator.hpp>
 #include <boost/property_tree/exceptions.hpp>
 #include <boost/property_tree/detail/ptree_utils.hpp>
+#include <boost/property_tree/detail/optional_type.hpp>
 
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/indexed_by.hpp>
@@ -25,7 +26,6 @@
 #include <boost/multi_index/member.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/throw_exception.hpp>
-#include <boost/optional.hpp>
 #include <utility>                  // for std::pair
 
 namespace boost { namespace property_tree

--- a/include/boost/property_tree/ptree_fwd.hpp
+++ b/include/boost/property_tree/ptree_fwd.hpp
@@ -61,8 +61,8 @@ namespace boost { namespace property_tree
         typename internal_type;
         typename external_type;
 
-        boost::optional<external_type> Tr::get_value(internal_type);
-        boost::optional<internal_type> Tr::put_value(external_type);
+        optional<external_type> Tr::get_value(internal_type);
+        optional<internal_type> Tr::put_value(external_type);
     }
 #endif
     /// If you want to use a custom key type, specialize this struct for it

--- a/include/boost/property_tree/stream_translator.hpp
+++ b/include/boost/property_tree/stream_translator.hpp
@@ -12,9 +12,8 @@
 #define BOOST_PROPERTY_TREE_STREAM_TRANSLATOR_HPP_INCLUDED
 
 #include <boost/property_tree/ptree_fwd.hpp>
+#include <boost/property_tree/detail/optional_type.hpp>
 
-#include <boost/optional.hpp>
-#include <boost/optional/optional_io.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/decay.hpp>
 #include <boost/type_traits/integral_constant.hpp>
@@ -191,24 +190,24 @@ namespace boost { namespace property_tree
             : m_loc(loc)
         {}
 
-        boost::optional<E> get_value(const internal_type &v) {
+        optional<E> get_value(const internal_type &v) {
             std::basic_istringstream<Ch, Traits, Alloc> iss(v);
             iss.imbue(m_loc);
             E e;
             customized::extract(iss, e);
             if(iss.fail() || iss.bad() || iss.get() != Traits::eof()) {
-                return boost::optional<E>();
+                return optional<E>();
             }
             return e;
         }
-        boost::optional<internal_type> put_value(const E &v) {
+        optional<internal_type> put_value(const E &v) {
             std::basic_ostringstream<Ch, Traits, Alloc> oss;
             oss.imbue(m_loc);
             customized::insert(oss, v);
             if(oss) {
                 return oss.str();
             }
-            return boost::optional<internal_type>();
+            return optional<internal_type>();
         }
 
     private:

--- a/include/boost/property_tree/string_path.hpp
+++ b/include/boost/property_tree/string_path.hpp
@@ -15,11 +15,11 @@
 #include <boost/property_tree/id_translator.hpp>
 #include <boost/property_tree/exceptions.hpp>
 #include <boost/property_tree/detail/ptree_utils.hpp>
+#include <boost/property_tree/detail/optional_type.hpp>
 
 #include <boost/static_assert.hpp>
 #include <boost/assert.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/optional.hpp>
 #include <boost/throw_exception.hpp>
 #include <algorithm>
 #include <string>


### PR DESCRIPTION
I made std::optional be able to optionally use in property_tree by defining `BOOST_PROPERTY_TREE_USE_STD_OPTIONAL`.

Usage in CMake:
```cmake
target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
target_compile_definitions(${PROJECT_NAME} PRIVATE BOOST_PROPERTY_TREE_USE_STD_OPTIONAL)
```