### PR TITLE
Create CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.8)
+project(property_tree
+        VERSION 1.75.0
+        LANGUAGES CXX
+)
+
+include(GNUInstallDirs)
+option(VERBOSE "Use verbose output" OFF)
+set(CMAKE_VERBOSE_MAKEFILE ${VERBOSE})
+
+message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
+add_library(${PROJECT_NAME} INTERFACE)
+add_library(Boost::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+target_include_directories(${PROJECT_NAME} INTERFACE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+set(CONFIG_VERSION_FILE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake)
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+        ${CONFIG_VERSION_FILE} COMPATIBILITY AnyNewerVersion
+)
+
+install(DIRECTORY include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING PATTERN "*.hpp"
+)
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}-config
+)
+install(EXPORT ${PROJECT_NAME}-config
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}
+        NAMESPACE Boost::
+)
+install(FILES ${CONFIG_VERSION_FILE}
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}
+)
+
+option(BUILD_TESTING "Do not build tests by default" OFF)
+include(CTest)
+if(BUILD_TESTING AND ${CMAKE_SOURCE_DIR} STREQUAL ${PROJECT_SOURCE_DIR})
+    add_subdirectory(test)
+endif()
+
+option(BUILD_EXAMPLES "Do not build examples by default" OFF)
+if(BUILD_EXAMPLES AND ${CMAKE_SOURCE_DIR} STREQUAL ${PROJECT_SOURCE_DIR})
+    add_subdirectory(examples)
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(EXAMPLE_NAMES
+        custom_data_type
+        debug_settings
+#        empty_ptree_trick FIXME: compile error
+        info_grammar_spirit
+        speed_test
+)
+
+find_package(Threads REQUIRED)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(Boost 1.67.0 REQUIRED)
+
+foreach(EXAMPLE_NAME ${EXAMPLE_NAMES})
+    message(STATUS ${PROJECT_BINARY_DIR})
+
+    add_executable(${EXAMPLE_NAME} ${EXAMPLE_NAME}.cpp)
+    target_compile_features(${EXAMPLE_NAME} PRIVATE cxx_std_11)
+    target_compile_options(${EXAMPLE_NAME} PRIVATE -Wall -Wextra)
+    target_include_directories(${EXAMPLE_NAME}
+            PRIVATE ${Boost_INCLUDE_DIRS}
+            PRIVATE ${CMAKE_SOURCE_DIR}/include
+    )
+    add_custom_target(example-${EXAMPLE_NAME})
+    add_custom_command(TARGET example-${EXAMPLE_NAME}
+            POST_BUILD
+            COMMAND ${EXAMPLE_NAME}
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/examples
+    )
+endforeach ()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,54 @@
+set(TEST_NAMES
+        sandbox # FIXME: test fails
+        test_info_parser
+        test_ini_parser
+        test_property_tree # FIXME: test fails
+        test_xml_parser_rapidxml
+)
+
+find_package(Threads REQUIRED)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(Boost 1.67.0 REQUIRED COMPONENTS
+        serialization
+        unit_test_framework
+)
+
+function(make_test TEST_NAME)
+    target_compile_features(${TEST_NAME} PRIVATE cxx_std_11)
+    target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra)
+    target_include_directories(${TEST_NAME}
+            PRIVATE ${Boost_INCLUDE_DIRS}
+            PRIVATE ${CMAKE_SOURCE_DIR}/include
+            PRIVATE ${CMAKE_SOURCE_DIR}/test
+    )
+
+    if (${TEST_NAME} STREQUAL test_property_tree)
+        target_link_libraries(${TEST_NAME} ${Boost_SERIALIZATION_LIBRARY})
+    endif()
+
+    if (${TEST_NAME} STREQUAL test_json_parser OR ${TEST_NAME} STREQUAL test_info_parser)
+        target_link_libraries(${TEST_NAME} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+    endif()
+
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME} WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+endfunction()
+
+foreach(TEST_NAME ${TEST_NAMES})
+    add_executable(${TEST_NAME} ${TEST_NAME}.cpp)
+    make_test(${TEST_NAME})
+endforeach ()
+
+add_executable(test_multi_module
+        test_multi_module1.cpp
+        test_multi_module2.cpp
+)
+make_test(test_multi_module)
+
+add_executable(test_json_parser
+        test_json_parser.cpp
+        test_json_parser2.cpp
+)
+make_test(test_json_parser)
+
+enable_testing()


### PR DESCRIPTION
I created CMakeLists.txt on the root, test, and examples directories to make this library managed by CMake.

## Installation
```shell
$ mkdir build && cd build
build/$ cmake ..
build/$ make
build/$ make install
```

## Running Tests
```shell
$ mkdir build && cd build
build/$ cmake .. -DBUILD_TESTING=ON
build/$ make
build/$ make test
```

## Running Examples
```shell
$ mkdir build && cd build
build/$ cmake .. -DBUILD_EXAMPLES=ON
build/$ make
build/$ make example-${EXAMPLE_NAME}
```
