### PR TITLE
Flush streams before checking for write errors

### DIFF
--- a/include/boost/property_tree/detail/info_parser_write.hpp
+++ b/include/boost/property_tree/detail/info_parser_write.hpp
@@ -138,6 +138,7 @@ namespace boost { namespace property_tree { namespace info_parser
                              const info_writer_settings<typename Ptree::key_type::value_type> &settings)
     {
         write_info_helper(stream, pt, -1, settings);
+        stream.flush();
         if (!stream.good())
             BOOST_PROPERTY_TREE_THROW(info_parser_error("write error", filename, 0));
     }

--- a/include/boost/property_tree/detail/xml_parser_write.hpp
+++ b/include/boost/property_tree/detail/xml_parser_write.hpp
@@ -186,6 +186,7 @@ namespace boost { namespace property_tree { namespace xml_parser
                 << settings.encoding
                 << detail::widen<Str>("\"?>\n");
         write_xml_element(stream, Str(), pt, -1, settings);
+        stream.flush();
         if (!stream)
             BOOST_PROPERTY_TREE_THROW(xml_parser_error("write error", filename, 0));
     }

--- a/include/boost/property_tree/ini_parser.hpp
+++ b/include/boost/property_tree/ini_parser.hpp
@@ -320,6 +320,10 @@ namespace boost { namespace property_tree { namespace ini_parser
             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
                 e.message(), filename, e.line()));
         }
+        stream.flush();
+        if (!stream)
+            BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                "write error", filename, 0));
     }
 
 } } }

--- a/include/boost/property_tree/json_parser/detail/write.hpp
+++ b/include/boost/property_tree/json_parser/detail/write.hpp
@@ -158,7 +158,7 @@ namespace boost { namespace property_tree { namespace json_parser
         if (!verify_json(pt, 0))
             BOOST_PROPERTY_TREE_THROW(json_parser_error("ptree contains data that cannot be represented in JSON format", filename, 0));
         write_json_helper(stream, pt, 0, pretty);
-        stream << std::endl;
+        stream << std::endl; // outputting endl performs flush
         if (!stream.good())
             BOOST_PROPERTY_TREE_THROW(json_parser_error("write error", filename, 0));
     }


### PR DESCRIPTION
The last write (and error) may happen on flush. Fixes #56.