### PR TITLE
Fix names of targets in CMake build:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
             install: clang-7
           - toolset: clang
             compiler: clang++-8
-            cxxstd: "03,11,14,17,2a"
+            cxxstd: "03,11,14,17"
             os: ubuntu-20.04
             install: clang-8
           - toolset: clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ else()
     )
 endif()
 
-if(BUILD_TESTING)
+if(BOOST_PROPERTY_TREE_BUILD_TESTS)
     include(CTest)
     add_subdirectory(test)
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,42 +16,25 @@ source_group("test" FILES
     speed_test.cpp
 )
 
+macro(add_example)
+    cmake_parse_arguments("addex" "" "NAME" "SRCS;DEPS" ${ARGN})
+    if("${addex_NAME}" STREQUAL "")
+        message(FATAL_ERROR "add_example: no NAME")
+    endif()
+    if("${addex_SRCS}" STREQUAL "")
+        message(FATAL_ERROR "add_example: no SRCS")
+    endif()
+    message(STATUS "add_example: ${addex_NAME} SRCS: ${addex_SRCS} DEPS: ${addex_DEPS}")
+    add_executable("${PROJECT_NAME}-example-${addex_NAME}"
+        ${addex_SRCS})
+    set_property(TARGET "${PROJECT_NAME}-example-${addex_NAME}" PROPERTY FOLDER "example")
+    target_link_libraries("${PROJECT_NAME}-example-${addex_NAME}" PRIVATE ${addex_DEPS})
+endmacro()
 #
 
-add_executable(custom_data_type
-    custom_data_type.cpp
-)
-set_property(TARGET custom_data_type PROPERTY FOLDER "example")
-target_link_libraries(custom_data_type PRIVATE Boost::property_tree)
-
-#
-
-add_executable(debug_settings
-    debug_settings.cpp
-)
-set_property(TARGET debug_settings PROPERTY FOLDER "example")
-target_link_libraries(debug_settings PRIVATE Boost::property_tree)
-
-#
-
-add_executable(empty_ptree_trick
-    empty_ptree_trick.cpp
-)
-set_property(TARGET empty_ptree_trick PROPERTY FOLDER "example")
-target_link_libraries(empty_ptree_trick PRIVATE Boost::property_tree)
-
-#
-
-add_executable(info_grammar_spirit
-    info_grammar_spirit.cpp
-)
-set_property(TARGET info_grammar_spirit PROPERTY FOLDER "example")
-target_link_libraries(info_grammar_spirit PRIVATE Boost::property_tree)
-
-#
-
-add_executable(speed_test
-    speed_test.cpp
-)
-set_property(TARGET speed_test PROPERTY FOLDER "example")
-target_link_libraries(speed_test PRIVATE Boost::property_tree)
+add_example(NAME custom_data_type SRCS custom_data_type.cpp DEPS Boost::property_tree)
+add_example(NAME debug_settings SRCS debug_settings.cpp DEPS Boost::property_tree)
+configure_file(debug_settings.xml debug_settings.xml COPYONLY)
+add_example(NAME empty_ptree_trick SRCS empty_ptree_trick.cpp DEPS Boost::property_tree)
+add_example(NAME info_grammar_spirit SRCS info_grammar_spirit.cpp DEPS Boost::property_tree)
+add_example(NAME speed_test SRCS speed_test.cpp DEPS Boost::property_tree)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,10 +14,11 @@ list(FILTER BOOST_PROPERTY_TREE_TESTS_FILES EXCLUDE REGEX "^${CMAKE_CURRENT_SOUR
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES ${BOOST_PROPERTY_TREE_TESTS_FILES})
 
 macro(PTREE_TEST name)
-    add_executable("${name}" ${ARGN})
-    target_include_directories("${name}" PRIVATE .)
-    target_link_libraries("${name}" PRIVATE Boost::property_tree Boost::serialization)
-    add_test(NAME "property_tree-${name}" COMMAND "${name}")
+    message(STATUS "ptree_test ${PROJECT_NAME}-${name} SRCS ${ARGN}")
+    add_executable("${PROJECT_NAME}-${name}" ${ARGN})
+    target_include_directories("${PROJECT_NAME}-${name}" PRIVATE .)
+    target_link_libraries("${PROJECT_NAME}-${name}" PRIVATE Boost::property_tree Boost::serialization)
+    add_test(NAME "${PROJECT_NAME}-${name}" COMMAND "${PROJECT_NAME}-${name}")
 endmacro()
 
 PTREE_TEST(test-multi test_multi_module1.cpp test_multi_module2.cpp)


### PR DESCRIPTION
This project's CMakeLists.txt must exist in the boost ecosystem. In
order to avoid ambiguity of target names across boost libraries, targets
in this project are prefixed with boost_property_tree-