### PR TITLE
Update CMakeLists.txt, test/CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,23 +14,6 @@ set(BOOST_PROPERTY_TREE_VERSION ${BOOST_SUPERPROJECT_VERSION})
 
 project(boost_property_tree VERSION "${BOOST_PROPERTY_TREE_VERSION}" LANGUAGES CXX)
 
-option(BOOST_PROPERTY_TREE_BUILD_TESTS "Build boost::property_tree tests" ${BUILD_TESTING})
-option(BOOST_PROPERTY_TREE_BUILD_EXAMPLES "Build boost::property_tree examples" ${BOOST_PROPERTY_TREE_BUILD_TESTS})
-
-file(GLOB_RECURSE BOOST_PROPERTY_TREE_HEADERS $<$<VERSION_GREATER_EQUAL:${CMAKE_VERSION},3.12>:CONFIGURE_DEPENDS>
-    include/boost/*.hpp
-    include/boost/*.ipp
-    include/boost/*.natvis
-)
-
-set(BOOST_PROPERTY_TREE_SOURCES
-)
-
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include/boost PREFIX "" FILES ${BOOST_PROPERTY_TREE_HEADERS})
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX "" FILES ${BOOST_PROPERTY_TREE_SOURCES})
-
 add_library(boost_property_tree INTERFACE)
 add_library(Boost::property_tree ALIAS boost_property_tree)
 
@@ -38,7 +21,7 @@ target_include_directories(boost_property_tree INTERFACE include)
 
 if(BOOST_SUPERPROJECT_VERSION)
     #
-    # Building as part of Boost superproject tree, with Boost as dependency.
+    # Building as part of Boost superproject tree.
     #
     target_link_libraries(boost_property_tree
       INTERFACE
@@ -59,7 +42,33 @@ if(BOOST_SUPERPROJECT_VERSION)
         Boost::type_traits
     )
 
-elseif(BOOST_PROPERTY_TREE_IN_BOOST_TREE)
+    if(BUILD_TESTING)
+        add_subdirectory(test)
+    endif()
+
+    return()
+endif()
+
+# Bulding outside the Boost superproject
+
+option(BOOST_PROPERTY_TREE_BUILD_TESTS "Build boost::property_tree tests" ${BUILD_TESTING})
+option(BOOST_PROPERTY_TREE_BUILD_EXAMPLES "Build boost::property_tree examples" ${BOOST_PROPERTY_TREE_BUILD_TESTS})
+
+file(GLOB_RECURSE BOOST_PROPERTY_TREE_HEADERS CONFIGURE_DEPENDS
+    include/boost/*.hpp
+    include/boost/*.ipp
+    include/boost/*.natvis
+)
+
+set(BOOST_PROPERTY_TREE_SOURCES
+)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include/boost PREFIX "" FILES ${BOOST_PROPERTY_TREE_HEADERS})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX "" FILES ${BOOST_PROPERTY_TREE_SOURCES})
+
+if(BOOST_PROPERTY_TREE_IN_BOOST_TREE)
     #
     # Building inside Boost tree, out of Boost superproject tree, with Boost as dependency.
     # e.g. on Travis or other CI, or when producing Visual Studio Solution and Projects.
@@ -92,9 +101,5 @@ if(BOOST_PROPERTY_TREE_BUILD_TESTS)
 endif()
 
 if(BOOST_PROPERTY_TREE_BUILD_EXAMPLES)
-    if (BOOST_SUPERPROJECT_VERSION)
-        message(STATUS "[property_tree] superproject build - skipping examples")
-    else()
-        add_subdirectory(examples)
-    endif()
+    add_subdirectory(examples)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,16 +8,21 @@
 # Official repository: https://github.com/boostorg/json
 #
 
-file(GLOB_RECURSE BOOST_PROPERTY_TREE_TESTS_FILES CONFIGURE_DEPENDS Jamfile *.cpp *.hpp)
+file(GLOB_RECURSE BOOST_PROPERTY_TREE_TESTS_FILES CONFIGURE_DEPENDS Jamfile.v2 *.cpp *.hpp)
 list(FILTER BOOST_PROPERTY_TREE_TESTS_FILES EXCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/cmake_install_test/.*$")
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES ${BOOST_PROPERTY_TREE_TESTS_FILES})
 
+if(NOT TARGET tests)
+    add_custom_target(tests)
+endif()
+
 macro(PTREE_TEST name)
-    message(STATUS "ptree_test ${PROJECT_NAME}-${name} SRCS ${ARGN}")
+    #message(STATUS "ptree_test ${PROJECT_NAME}-${name} SRCS ${ARGN}")
     add_executable("${PROJECT_NAME}-${name}" ${ARGN})
     target_include_directories("${PROJECT_NAME}-${name}" PRIVATE .)
     target_link_libraries("${PROJECT_NAME}-${name}" PRIVATE Boost::property_tree Boost::serialization)
+    add_dependencies(tests "${PROJECT_NAME}-${name}")
     add_test(NAME "${PROJECT_NAME}-${name}" COMMAND "${PROJECT_NAME}-${name}")
 endmacro()
 
@@ -29,56 +34,3 @@ PTREE_TEST(test-json-parser test_json_parser.cpp)
 PTREE_TEST(test-json-parser2 test_json_parser2.cpp)
 PTREE_TEST(test-ini-parser test_ini_parser.cpp)
 PTREE_TEST(test-xml-parser-rapidxml test_xml_parser_rapidxml.cpp)
-
-#[[
-add_executable(tests ${BOOST_PROPERTY_TREE_TESTS_FILES})
-target_include_directories(tests PRIVATE .)
-target_link_libraries(tests PRIVATE Boost::property_tree Boost::serialization Boost::unit_test_framework)
-add_test(NAME property_tree-tests COMMAND tests)
-]]
-
-#[[
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES limits.cpp main.cpp)
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/../src PREFIX "" FILES ../src/src.cpp)
-add_executable(limits limits.cpp main.cpp ../src/src.cpp Jamfile)
-
-target_compile_features(limits PUBLIC cxx_constexpr)
-
-target_include_directories(limits PRIVATE ../include .)
-target_compile_definitions(limits PRIVATE
-    BOOST_PROPERTY_TREE_MAX_STRING_SIZE=1000
-    BOOST_PROPERTY_TREE_MAX_STRUCTURED_SIZE=20
-    BOOST_PROPERTY_TREE_STACK_BUFFER_SIZE=256
-    BOOST_PROPERTY_TREE_NO_LIB=1
-)
-]]
-
-if(BOOST_SUPERPROJECT_VERSION)
-#[[
-    target_link_libraries(limits
-        PRIVATE
-            Boost::align
-            Boost::assert
-            Boost::config
-            Boost::container
-            Boost::exception
-            Boost::system
-            Boost::throw_exception
-            Boost::utility
-    )
-]]
-elseif(BOOST_PROPERTY_TREE_IN_BOOST_TREE)
-#[[
-    target_include_directories(limits PRIVATE ${BOOST_ROOT})
-    target_link_directories(limits PRIVATE ${BOOST_ROOT}/stage/lib)
-]]
-else()
-#[[
-    target_link_libraries(limits
-        PRIVATE
-            Boost::system
-            Boost::container
-    )
-]]
-endif()
-


### PR DESCRIPTION
In the root CML, this moves the options/folders outside the BOOST_SUPERPROJECT_VERSION case. In tests/CML, it attaches the tests to the `tests` target, which will be the Boost-wide convention for building the test executables. They are still left attached to the `all` target as well, because I didn't know if that was relied upon. If not, the test executables should use EXCLUDE_FROM_ALL.