### PR TITLE
handle xml writing of null keys

### DIFF
--- a/include/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
+++ b/include/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
@@ -31,7 +31,8 @@ namespace boost { namespace property_tree { namespace xml_parser
             case node_element: 
             {
                 // Create node
-                Ptree &pt_node = pt.push_back(std::make_pair(node->name(),
+                Ptree &pt_node = pt.push_back(std::make_pair(
+                    (node->name() == "nullkey-3cb6534e-d358-4705-9e74-fee06453661e" ? "" : node->name()),
                                                              Ptree()))->second;
 
                 // Copy attributes

--- a/include/boost/property_tree/detail/xml_parser_write.hpp
+++ b/include/boost/property_tree/detail/xml_parser_write.hpp
@@ -72,7 +72,7 @@ namespace boost { namespace property_tree { namespace xml_parser
         typedef typename Ptree::key_type::value_type Ch;
         typedef typename Ptree::key_type Str;
         typedef typename Ptree::const_iterator It;
-        const char* nullkey = R"nullkey(nullkey-3cb6534e-d358-4705-9e74-fee06453661e)nullkey";
+        const char* nullkey = "nullkey-3cb6534e-d358-4705-9e74-fee06453661e";
 
         bool want_pretty = settings.indent_count > 0;
         // Find if elements present

--- a/include/boost/property_tree/detail/xml_parser_write.hpp
+++ b/include/boost/property_tree/detail/xml_parser_write.hpp
@@ -72,6 +72,7 @@ namespace boost { namespace property_tree { namespace xml_parser
         typedef typename Ptree::key_type::value_type Ch;
         typedef typename Ptree::key_type Str;
         typedef typename Ptree::const_iterator It;
+        const char* nullkey = R"nullkey(nullkey-3cb6534e-d358-4705-9e74-fee06453661e)nullkey";
 
         bool want_pretty = settings.indent_count > 0;
         // Find if elements present
@@ -96,7 +97,7 @@ namespace boost { namespace property_tree { namespace xml_parser
             if (indent >= 0)
             {
                 write_xml_indent(stream,indent,settings);
-                stream << Ch('<') << key << 
+                stream << Ch('<') << (key.empty() ? nullkey : key) << 
                           Ch('/') << Ch('>');
                 if (want_pretty)
                     stream << Ch('\n');
@@ -109,7 +110,7 @@ namespace boost { namespace property_tree { namespace xml_parser
             {
                 // Write opening brace and key
                 write_xml_indent(stream,indent,settings);
-                stream << Ch('<') << key;
+                stream << Ch('<') << (key.empty() ? nullkey : key);
 
                 // Write attributes
                 if (optional<const Ptree &> attribs = pt.get_child_optional(xmlattr<Str>()))
@@ -167,7 +168,7 @@ namespace boost { namespace property_tree { namespace xml_parser
             {
                 if (has_elements)
                     write_xml_indent(stream,indent,settings);
-                stream << Ch('<') << Ch('/') << key << Ch('>');
+                stream << Ch('<') << Ch('/') << (key.empty() ? nullkey : key) << Ch('>');
                 if (want_pretty)
                     stream << Ch('\n');
             }

--- a/test/test_xml_parser_common.hpp
+++ b/test/test_xml_parser_common.hpp
@@ -110,7 +110,7 @@ void test_xml_parser()
     generic_parser_test_ok<Ptree, ReadFuncWS, WriteFuncWS>
     (
         ReadFuncWS(), WriteFuncWS(), ok_data_6, NULL,
-        "testok6a.xml", NULL, "testok6aout.xml", 15, 23, 89
+        "testok6a.xml", NULL, "testok6aout.xml", 4, 1, 2
     );
 
     generic_parser_test_error<Ptree, ReadFuncWS, WriteFuncWS, xml_parser_error>

--- a/test/test_xml_parser_common.hpp
+++ b/test/test_xml_parser_common.hpp
@@ -107,6 +107,12 @@ void test_xml_parser()
         3, umlautsize<char_type>(), 12
     );
 
+    generic_parser_test_ok<Ptree, ReadFuncWS, WriteFuncWS>
+    (
+        ReadFuncWS(), WriteFuncWS(), ok_data_6, NULL,
+        "testok6a.xml", NULL, "testok6aout.xml", 15, 23, 89
+    );
+
     generic_parser_test_error<Ptree, ReadFuncWS, WriteFuncWS, xml_parser_error>
     (
         ReadFuncWS(), WriteFuncWS(), error_data_1, NULL,

--- a/test/xml_parser_test_data.hpp
+++ b/test/xml_parser_test_data.hpp
@@ -747,6 +747,13 @@ const char ok_data_5[] =
     "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" /*39 chars*/
     "<doc>\xC3\xA4</doc>";
 
+const char *ok_data_6 =
+    "<a>"
+    "<nullkey-3cb6534e-d358-4705-9e74-fee06453661e>"
+    "<b>c</b>"
+    "</nullkey-3cb6534e-d358-4705-9e74-fee06453661e>"
+    "</a>";
+
 // Erroneous
 const char *error_data_1 = 
     "a";      // bogus character


### PR DESCRIPTION
boost::property_tree can have nulls as keys.
In particular, json read typically generates child nodes with null keys
as part of array processing.
Place a nonce (3cb6534e-d358-4705-9e74-fee06453661e) as a unique tag
name for null keys in write_xml.