### PR TITLE
Replaced void* with boost::any

### DIFF
--- a/include/boost/property_tree/ptree.hpp
+++ b/include/boost/property_tree/ptree.hpp
@@ -26,6 +26,7 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/optional.hpp>
+#include <boost/any.hpp>
 #include <utility>                  // for std::pair
 
 namespace boost { namespace property_tree
@@ -82,16 +83,13 @@ namespace boost { namespace property_tree
         typedef typename path_of<Key>::type          path_type;
 
 
-        // The big five
+        // Constructors
+        // copy and move constructors and assignment operators are implicitly created
 
         /** Creates a node with no children and default-constructed data. */
         basic_ptree();
         /** Creates a node with no children and a copy of the given data. */
         explicit basic_ptree(const data_type &data);
-        basic_ptree(const self_type &rhs);
-        ~basic_ptree();
-        /** Basic guarantee only. */
-        self_type &operator =(const self_type &rhs);
 
         /** Swap with other tree. Only constant-time and nothrow if the
          * data type's swap is.
@@ -491,7 +489,7 @@ namespace boost { namespace property_tree
         data_type m_data;
         // Hold the children - this is a void* because we can't complete the
         // container type within the class.
-        void* m_children;
+        boost::any m_children;
 
         // Getter tree-walk. Not const-safe! Gets the node the path refers to,
         // or null. Destroys p's value.


### PR DESCRIPTION
I think this would be a great improvement to the library.

Makes default/implicitly created copy constructors well behaved
Implicit destructor now also works
which makes move constructor available and implicitly created
by using the any we are compliant with the rule of 0

Note on moved from state:
Move operations move the contents of the any, and not necessarily the container it contains.  So assignment operators and clear would return it to a specified state.  Which is to my understanding the requirement for "valid but unspecified".  All other operations will throw.
clear() reconstructs the child container if not present.

If more functionality is desired post-move we would have to declare/define all the constructors and assignment operators.  Alternatively, like the note about ctors from the original maintainers we could make the child container on demand, which isn't as difficult with the any.  I left some commented out lines which would probably capture most of it.

It shouldn't have any outward functional changes best I can tell.