### PR TITLE
Fix different signedness comparison on Arm

### DIFF
--- a/include/boost/property_tree/detail/ptree_utils.hpp
+++ b/include/boost/property_tree/detail/ptree_utils.hpp
@@ -73,7 +73,7 @@ namespace boost { namespace property_tree { namespace detail
         Str result;
         while (*text)
         {
-            if (*text < 0 || *text > (std::numeric_limits<char>::max)())
+            if (*text < 0 || *text > static_cast<char_type>((std::numeric_limits<char>::max)()))
                 result += '*';
             else
                 result += typename Str::value_type(*text);


### PR DESCRIPTION
wchar_t is an unsigned on Arm, therefore a promotion is necessary here to correctly perform the comparison

More information about Armv8 types on https://developer.arm.com/documentation/den0024/a/Porting-to-A64/Data-types