### PR TITLE
Fix build when `BOOST_BIND_NO_PLACEHOLDERS` is defined

### DIFF
--- a/include/boost/property_tree/json_parser/detail/parser.hpp
+++ b/include/boost/property_tree/json_parser/detail/parser.hpp
@@ -5,6 +5,7 @@
 
 #include <boost/core/ref.hpp>
 #include <boost/bind/bind.hpp>
+#include <boost/bind/placeholders.hpp>
 #include <boost/format.hpp>
 
 #include <iterator>


### PR DESCRIPTION
`<boost/bind/placeholders.hpp>` should be explicitly included here, because `<boost/bind/bind.hpp>` may not include it depending on whether `BOOST_BIND_NO_PLACEHOLDERS` is defined or not.