### PR TITLE
refactor: use core/swap over utility/swap

### DIFF
--- a/include/boost/property_tree/detail/ptree_implementation.hpp
+++ b/include/boost/property_tree/detail/ptree_implementation.hpp
@@ -11,10 +11,10 @@
 #ifndef BOOST_PROPERTY_TREE_DETAIL_PTREE_IMPLEMENTATION_HPP_INCLUDED
 #define BOOST_PROPERTY_TREE_DETAIL_PTREE_IMPLEMENTATION_HPP_INCLUDED
 
+#include <boost/core/swap.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/assert.hpp>
-#include <boost/utility/swap.hpp>
 #include <memory>
 
 #if (defined(BOOST_MSVC) && \


### PR DESCRIPTION
The later is deprecated.