### PR TITLE
Remove empty destructors (redundant since C++11)

### DIFF
--- a/include/boost/property_tree/detail/exception_implementation.hpp
+++ b/include/boost/property_tree/detail/exception_implementation.hpp
@@ -35,20 +35,12 @@ namespace boost { namespace property_tree
     {
     }
 
-    inline ptree_error::~ptree_error() throw()
-    {
-    }
-
     ///////////////////////////////////////////////////////////////////////////
     // ptree_bad_data
 
     template<class D> inline
     ptree_bad_data::ptree_bad_data(const std::string &w, const D &d):
         ptree_error(w), m_data(d)
-    {
-    }
-
-    inline ptree_bad_data::~ptree_bad_data() throw()
     {
     }
 
@@ -66,10 +58,6 @@ namespace boost { namespace property_tree
         ptree_error(detail::prepare_bad_path_what(w, p)), m_path(p)
     {
 
-    }
-
-    inline ptree_bad_path::~ptree_bad_path() throw()
-    {
     }
 
     template<class P> inline

--- a/include/boost/property_tree/detail/file_parser_error.hpp
+++ b/include/boost/property_tree/detail/file_parser_error.hpp
@@ -23,7 +23,7 @@ namespace boost { namespace property_tree
     public:
 
         ///////////////////////////////////////////////////////////////////////
-        // Construction & destruction
+        // Construction
 
         // Construct error
         file_parser_error(const std::string &msg,
@@ -33,8 +33,6 @@ namespace boost { namespace property_tree
             m_message(msg), m_filename(file), m_line(l)
         {
         }
-
-        ~file_parser_error() throw() override = default;
 
         ///////////////////////////////////////////////////////////////////////
         // Data access

--- a/include/boost/property_tree/detail/file_parser_error.hpp
+++ b/include/boost/property_tree/detail/file_parser_error.hpp
@@ -34,11 +34,7 @@ namespace boost { namespace property_tree
         {
         }
 
-        BOOST_DEFAULTED_FUNCTION(~file_parser_error() throw() BOOST_OVERRIDE,
-            // gcc 3.4.2 complains about lack of throw specifier on compiler
-            // generated dtor
-        {
-        })
+        ~file_parser_error() throw() override = default;
 
         ///////////////////////////////////////////////////////////////////////
         // Data access

--- a/include/boost/property_tree/detail/file_parser_error.hpp
+++ b/include/boost/property_tree/detail/file_parser_error.hpp
@@ -34,11 +34,11 @@ namespace boost { namespace property_tree
         {
         }
 
-        ~file_parser_error() throw() BOOST_OVERRIDE
+        BOOST_DEFAULTED_FUNCTION(~file_parser_error() throw() BOOST_OVERRIDE,
             // gcc 3.4.2 complains about lack of throw specifier on compiler
             // generated dtor
         {
-        }
+        })
 
         ///////////////////////////////////////////////////////////////////////
         // Data access

--- a/include/boost/property_tree/detail/rapidxml.hpp
+++ b/include/boost/property_tree/detail/rapidxml.hpp
@@ -59,7 +59,7 @@ namespace boost { namespace property_tree { namespace detail {namespace rapidxml
 
         //! Gets human readable description of error.
         //! \return Pointer to null terminated description of the error.
-        const char *what() const throw() BOOST_OVERRIDE
+        const char *what() const throw() override
         {
             return m_what;
         }

--- a/include/boost/property_tree/exceptions.hpp
+++ b/include/boost/property_tree/exceptions.hpp
@@ -31,7 +31,7 @@ namespace boost { namespace property_tree
         /// @param what The message to associate with this error.
         ptree_error(const std::string &what);
 
-        BOOST_DEFAULTED_FUNCTION(~ptree_error() throw() BOOST_OVERRIDE, {});
+        ~ptree_error() throw() override = default;
     };
 
 
@@ -48,7 +48,7 @@ namespace boost { namespace property_tree
         template<class T> ptree_bad_data(const std::string &what,
                                          const T &data);
 
-        BOOST_DEFAULTED_FUNCTION(~ptree_bad_data() throw() BOOST_OVERRIDE, {});
+        ~ptree_bad_data() throw() override = default;
 
         /// Retrieve the data associated with this error. This is the source
         /// value that failed to be translated. You need to explicitly
@@ -70,7 +70,7 @@ namespace boost { namespace property_tree
         template<class T> ptree_bad_path(const std::string &what,
                                          const T &path);
 
-        BOOST_DEFAULTED_FUNCTION(~ptree_bad_path() throw() BOOST_OVERRIDE, {});
+        ~ptree_bad_path() throw() override = default;
 
         /// Retrieve the invalid path. You need to explicitly specify the
         /// type of path.

--- a/include/boost/property_tree/exceptions.hpp
+++ b/include/boost/property_tree/exceptions.hpp
@@ -30,8 +30,6 @@ namespace boost { namespace property_tree
         /// Instantiate a ptree_error instance with the given message.
         /// @param what The message to associate with this error.
         ptree_error(const std::string &what);
-
-        ~ptree_error() throw() override = default;
     };
 
 
@@ -47,8 +45,6 @@ namespace boost { namespace property_tree
         ///             of the translation failure.
         template<class T> ptree_bad_data(const std::string &what,
                                          const T &data);
-
-        ~ptree_bad_data() throw() override = default;
 
         /// Retrieve the data associated with this error. This is the source
         /// value that failed to be translated. You need to explicitly
@@ -69,8 +65,6 @@ namespace boost { namespace property_tree
         /// @param path The path that could not be found in the property_tree.
         template<class T> ptree_bad_path(const std::string &what,
                                          const T &path);
-
-        ~ptree_bad_path() throw() override = default;
 
         /// Retrieve the invalid path. You need to explicitly specify the
         /// type of path.

--- a/include/boost/property_tree/exceptions.hpp
+++ b/include/boost/property_tree/exceptions.hpp
@@ -31,7 +31,7 @@ namespace boost { namespace property_tree
         /// @param what The message to associate with this error.
         ptree_error(const std::string &what);
 
-        ~ptree_error() throw() BOOST_OVERRIDE;
+        BOOST_DEFAULTED_FUNCTION(~ptree_error() throw() BOOST_OVERRIDE, {});
     };
 
 
@@ -48,7 +48,7 @@ namespace boost { namespace property_tree
         template<class T> ptree_bad_data(const std::string &what,
                                          const T &data);
 
-        ~ptree_bad_data() throw() BOOST_OVERRIDE;
+        BOOST_DEFAULTED_FUNCTION(~ptree_bad_data() throw() BOOST_OVERRIDE, {});
 
         /// Retrieve the data associated with this error. This is the source
         /// value that failed to be translated. You need to explicitly
@@ -70,7 +70,7 @@ namespace boost { namespace property_tree
         template<class T> ptree_bad_path(const std::string &what,
                                          const T &path);
 
-        ~ptree_bad_path() throw() BOOST_OVERRIDE;
+        BOOST_DEFAULTED_FUNCTION(~ptree_bad_path() throw() BOOST_OVERRIDE, {});
 
         /// Retrieve the invalid path. You need to explicitly specify the
         /// type of path.


### PR DESCRIPTION
The compiler-generated copy constructor and copy assignment operator are deprecated since C++11 on classes with user-declared destructors.

The compiler-generated destructor is `noexcept` since C++11, so there is no need to declare/define a user-provided or explicitly defaulted destructor.

This change allows clean compilation with the -Wdeprecated-copy-dtor/-Wdeprecated-copy-with-user-provided-dtor flag.