### PR TITLE
Switch to `boost::core::invoke_swap`

### DIFF
--- a/include/boost/property_tree/detail/ptree_implementation.hpp
+++ b/include/boost/property_tree/detail/ptree_implementation.hpp
@@ -14,7 +14,7 @@
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/assert.hpp>
-#include <boost/utility/swap.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <memory>
 
 #if (defined(BOOST_MSVC) && \
@@ -211,7 +211,7 @@ namespace boost { namespace property_tree
     template<class K, class D, class C> inline
     void basic_ptree<K, D, C>::swap(basic_ptree<K, D, C> &rhs)
     {
-        boost::swap(m_data, rhs.m_data);
+        boost::core::invoke_swap(m_data, rhs.m_data);
         // Void pointers, no ADL necessary
         std::swap(m_children, rhs.m_children);
     }

--- a/include/boost/property_tree/detail/xml_parser_write.hpp
+++ b/include/boost/property_tree/detail/xml_parser_write.hpp
@@ -13,6 +13,7 @@
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/detail/xml_parser_utils.hpp>
+#include <boost/optional/optional.hpp>
 #include <string>
 #include <ostream>
 #include <iomanip>

--- a/include/boost/property_tree/id_translator.hpp
+++ b/include/boost/property_tree/id_translator.hpp
@@ -13,7 +13,7 @@
 
 #include <boost/property_tree/ptree_fwd.hpp>
 
-#include <boost/optional.hpp>
+#include <boost/optional/optional.hpp>
 #include <string>
 
 namespace boost { namespace property_tree

--- a/include/boost/property_tree/ptree.hpp
+++ b/include/boost/property_tree/ptree.hpp
@@ -23,9 +23,9 @@
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/member.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/core/enable_if.hpp>
 #include <boost/throw_exception.hpp>
-#include <boost/optional.hpp>
+#include <boost/optional/optional.hpp>
 #include <utility>                  // for std::pair
 
 namespace boost { namespace property_tree

--- a/include/boost/property_tree/stream_translator.hpp
+++ b/include/boost/property_tree/stream_translator.hpp
@@ -13,9 +13,9 @@
 
 #include <boost/property_tree/ptree_fwd.hpp>
 
-#include <boost/optional.hpp>
+#include <boost/optional/optional.hpp>
 #include <boost/optional/optional_io.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/core/enable_if.hpp>
 #include <boost/type_traits/decay.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 #include <sstream>

--- a/include/boost/property_tree/string_path.hpp
+++ b/include/boost/property_tree/string_path.hpp
@@ -19,7 +19,7 @@
 #include <boost/static_assert.hpp>
 #include <boost/assert.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/optional.hpp>
+#include <boost/optional/optional.hpp>
 #include <boost/throw_exception.hpp>
 #include <algorithm>
 #include <string>


### PR DESCRIPTION
`boost::swap` is deprecated and will be removed. Use `boost::core::invoke_swap` as a replacement.