### PR TITLE
Add support for modular build structure.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,23 +145,38 @@ jobs:
             container: ubuntu:23.10
             install: clang-17
           - toolset: clang
-            cxxstd: "11,14,17,2a"
-            os: macos-11
-          - toolset: clang
-            cxxstd: "11,14,17,20,2b"
-            os: macos-12
-          - toolset: clang
             cxxstd: "11,14,17,20,2b"
             os: macos-13
+          - toolset: clang
+            cxxstd: "11,14,17,20,2b"
+            os: macos-14
+          - toolset: clang
+            cxxstd: "11,14,17,20,23"
+            os: macos-15
 
     runs-on: ${{matrix.os}}
-    container: ${{matrix.container}}
+    container:
+      image: ${{ matrix.container }}
+      options: --privileged
+      volumes:
+        - /node20217:/node20217:rw,rshared
+        - ${{ startsWith(matrix.container, 'ubuntu:1') && '/node20217:/__e/node20:ro,rshared' || ' ' }}
+    timeout-minutes: 120
 
     defaults:
       run:
         shell: bash
 
     steps:
+      - name: install nodejs20glibc2.17
+        if: ${{ startsWith( matrix.container, 'ubuntu:1' ) }}
+        run: |
+          apt-get update
+          apt-get -yqq install xz-utils curl
+          curl -LO https://archives.boost.io/misc/node/node-v20.9.0-linux-x64-glibc-217.tar.xz
+          tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
+          ldd /__e/node20/bin/node
+
       - uses: actions/checkout@v3
 
       - name: Setup container environment
@@ -275,9 +290,9 @@ jobs:
         include:
           - os: ubuntu-20.04
           - os: ubuntu-22.04
-          - os: macos-11
-          - os: macos-12
           - os: macos-13
+          - os: macos-14
+          - os: macos-15
 
     runs-on: ${{matrix.os}}
 
@@ -323,9 +338,9 @@ jobs:
         include:
           - os: ubuntu-20.04
           - os: ubuntu-22.04
-          - os: macos-11
-          - os: macos-12
           - os: macos-13
+          - os: macos-14
+          - os: macos-15
 
     runs-on: ${{matrix.os}}
 
@@ -381,9 +396,9 @@ jobs:
         include:
           - os: ubuntu-20.04
           - os: ubuntu-22.04
-          - os: macos-11
-          - os: macos-12
           - os: macos-13
+          - os: macos-14
+          - os: macos-15
 
     runs-on: ${{matrix.os}}
 

--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,34 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/property_tree
+    : common-requirements
+        <source>/boost/any//boost_any
+        <source>/boost/assert//boost_assert
+        <source>/boost/bind//boost_bind
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/format//boost_format
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/multi_index//boost_multi_index
+        <source>/boost/optional//boost_optional
+        <source>/boost/range//boost_range
+        <source>/boost/serialization//boost_serialization
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_property_tree ]
+    [ alias all : examples test ]
+    ;
+
+call-if : boost-library property_tree
+    ;

--- a/build.jam
+++ b/build.jam
@@ -11,6 +11,7 @@ project /boost/property_tree
     : common-requirements
         <library>/boost/any//boost_any
         <library>/boost/assert//boost_assert
+        <library>/boost/bind//boost_bind
         <library>/boost/config//boost_config
         <library>/boost/core//boost_core
         <library>/boost/iterator//boost_iterator

--- a/build.jam
+++ b/build.jam
@@ -5,29 +5,32 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/any//boost_any
+    /boost/assert//boost_assert
+    /boost/bind//boost_bind
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/iterator//boost_iterator
+    /boost/mpl//boost_mpl
+    /boost/multi_index//boost_multi_index
+    /boost/optional//boost_optional
+    /boost/range//boost_range
+    /boost/serialization//boost_serialization
+    /boost/static_assert//boost_static_assert
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/property_tree
     : common-requirements
-        <library>/boost/any//boost_any
-        <library>/boost/assert//boost_assert
-        <library>/boost/bind//boost_bind
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/multi_index//boost_multi_index
-        <library>/boost/optional//boost_optional
-        <library>/boost/range//boost_range
-        <library>/boost/serialization//boost_serialization
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_property_tree ]
+    [ alias boost_property_tree : : : : <library>$(boost_dependencies) ]
     [ alias all : examples test ]
     ;
 
 call-if : boost-library property_tree
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -7,21 +7,21 @@ import project ;
 
 project /boost/property_tree
     : common-requirements
-        <source>/boost/any//boost_any
-        <source>/boost/assert//boost_assert
-        <source>/boost/bind//boost_bind
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/format//boost_format
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/multi_index//boost_multi_index
-        <source>/boost/optional//boost_optional
-        <source>/boost/range//boost_range
-        <source>/boost/serialization//boost_serialization
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/any//boost_any
+        <library>/boost/assert//boost_assert
+        <library>/boost/bind//boost_bind
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/format//boost_format
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/multi_index//boost_multi_index
+        <library>/boost/optional//boost_optional
+        <library>/boost/range//boost_range
+        <library>/boost/serialization//boost_serialization
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -9,10 +9,8 @@ project /boost/property_tree
     : common-requirements
         <library>/boost/any//boost_any
         <library>/boost/assert//boost_assert
-        <library>/boost/bind//boost_bind
         <library>/boost/config//boost_config
         <library>/boost/core//boost_core
-        <library>/boost/format//boost_format
         <library>/boost/iterator//boost_iterator
         <library>/boost/mpl//boost_mpl
         <library>/boost/multi_index//boost_multi_index

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/property_tree

--- a/build.jam
+++ b/build.jam
@@ -22,12 +22,11 @@ constant boost_dependencies :
     /boost/type_traits//boost_type_traits ;
 
 project /boost/property_tree
-    : common-requirements
-        <include>include
     ;
 
 explicit
-    [ alias boost_property_tree : : : : <library>$(boost_dependencies) ]
+    [ alias boost_property_tree : : :
+        : <include>include <library>$(boost_dependencies) ]
     [ alias all : examples test ]
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/property_tree
     : common-requirements

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -15,7 +15,7 @@ import quickbook ;
 
 doxygen autodoc
     :
-        [ glob ../../../boost/property_tree/*.hpp ]
+        [ glob ../include/boost/property_tree/*.hpp ]
     :
         <doxygen:param>EXTRACT_ALL=YES
         <doxygen:param>"PREDEFINED=\"BOOST_PROPERTY_TREE_DOXYGEN_INVOKED\" \\

--- a/examples/Jamfile.v2
+++ b/examples/Jamfile.v2
@@ -4,7 +4,8 @@
 # See http://www.boost.org/LICENSE_1_0.txt
 
 exe custom_data_type : custom_data_type.cpp ;
-exe debug_settings : debug_settings.cpp ;
+exe debug_settings : debug_settings.cpp
+    /boost/foreach//boost_foreach ;
 exe empty_ptree_trick : empty_ptree_trick.cpp ;
 exe info_grammar_spirit : info_grammar_spirit.cpp ;
 exe speed_test : speed_test.cpp ;

--- a/examples/Jamfile.v2
+++ b/examples/Jamfile.v2
@@ -8,4 +8,4 @@ exe debug_settings : debug_settings.cpp
     /boost/foreach//boost_foreach ;
 exe empty_ptree_trick : empty_ptree_trick.cpp ;
 exe info_grammar_spirit : info_grammar_spirit.cpp ;
-exe speed_test : speed_test.cpp ;
+exe speed_test : speed_test.cpp /boost/format//boost_format ;

--- a/examples/Jamfile.v2
+++ b/examples/Jamfile.v2
@@ -3,6 +3,8 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See http://www.boost.org/LICENSE_1_0.txt
 
+project : requirements <library>/boost/property_tree//boost_property_tree ;
+
 exe custom_data_type : custom_data_type.cpp ;
 exe debug_settings : debug_settings.cpp
     /boost/foreach//boost_foreach ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -42,7 +42,7 @@ for local file in [ glob-tree-ex ../include : *.hpp ]
 }
 
 compile ../examples/custom_data_type.cpp ;
-compile ../examples/debug_settings.cpp ;
+compile ../examples/debug_settings.cpp /boost/foreach//boost_foreach ;
 compile ../examples/empty_ptree_trick.cpp ;
 compile ../examples/info_grammar_spirit.cpp ;
 compile ../examples/speed_test.cpp ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -45,4 +45,4 @@ compile ../examples/custom_data_type.cpp ;
 compile ../examples/debug_settings.cpp /boost/foreach//boost_foreach ;
 compile ../examples/empty_ptree_trick.cpp ;
 compile ../examples/info_grammar_spirit.cpp ;
-compile ../examples/speed_test.cpp ;
+compile ../examples/speed_test.cpp /boost/format//boost_format ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -14,6 +14,8 @@ import testing ;
 project
     : requirements
 
+      <library>/boost/property_tree//boost_property_tree
+
       <link>static
       <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS=1
 


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.