### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
       - name: Run tests
         run: |
           cd ../boost-root
-          ./b2 libs/$LIBRARY/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} variant=debug,release
+          ./b2 -j1 libs/$LIBRARY/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} variant=debug,release
 
   windows:
     strategy:
@@ -311,7 +311,7 @@ jobs:
         shell: cmd
         run: |
           cd ../boost-root
-          b2 --abbreviate-paths libs/%LIBRARY%/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} address-model=${{matrix.addrmd}} ${{matrix.cxxflags}} variant=debug,release embed-manifest-via=linker
+          b2 -j1 --abbreviate-paths libs/%LIBRARY%/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} address-model=${{matrix.addrmd}} ${{matrix.cxxflags}} variant=debug,release embed-manifest-via=linker
 
   posix-cmake-subdir:
     strategy:


### PR DESCRIPTION
Running tests in parallel results in sporadic failures in `test_xml_parser_rapidxml`.