### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(boost_property_tree
     Boost::optional
     Boost::range
     Boost::serialization
-    Boost::static_assert
     Boost::throw_exception
     Boost::type_traits
 )

--- a/build.jam
+++ b/build.jam
@@ -17,7 +17,6 @@ constant boost_dependencies :
     /boost/optional//boost_optional
     /boost/range//boost_range
     /boost/serialization//boost_serialization
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits ;
 


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.